### PR TITLE
Implement core CellStyle methods

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -14,7 +14,13 @@ module.exports = {
   ],
   rules: {
     // Add custom rules here
-    'prettier/prettier': 'error',
+    'prettier/prettier': [
+     'error',
+      {
+        "endOfLine": "auto"
+      }
+    ],
+
     "@typescript-eslint/no-explicit-any": "off"
     // 'line-comment-postion': 'above',
   },

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -30,5 +30,5 @@ module.exports = {
   env: {
     "browser": true,
   },
-  ignorePatterns: ['vite.config.js'],
+  ignorePatterns: ['vite.config.js', '/dist/'],
 };

--- a/src/core/cloneable.ts
+++ b/src/core/cloneable.ts
@@ -1,0 +1,23 @@
+export default abstract class Cloneable<T extends object> {
+  protected constructor() {}
+
+  clone(other: T | undefined | null): this {
+    if (!other) return this;
+
+    for (const key in this) {
+      if (!Object.prototype.hasOwnProperty.call(other, key)) {
+        continue;
+      }
+
+      const property = Reflect.get(other, key);
+      if (property instanceof Cloneable) {
+        const propObj = Object.create(property);
+        Reflect.set(this, key, propObj.clone(property));
+        continue;
+      }
+      Reflect.set(this, key, property);
+    }
+
+    return this;
+  }
+}

--- a/src/core/evaluation/formatter.ts
+++ b/src/core/evaluation/formatter.ts
@@ -1,4 +1,9 @@
-export default abstract class Formatter {
-  constructor() {}
+import Cloneable from "../cloneable.ts";
+
+export default abstract class Formatter extends Cloneable<Formatter> {
+  protected constructor() {
+    super();
+  }
+
   abstract format(value: string): string | null;
 }

--- a/src/core/structure/cellStyle.ts
+++ b/src/core/structure/cellStyle.ts
@@ -9,14 +9,16 @@ export default class CellStyle {
 
   constructor(
     formatter: Formatter | null = null,
-    width: number = 30,
-    height: number = 10,
+    width?: number,
+    height?: number,
+    color?: [number, number, number],
+    borders?: [boolean, boolean, boolean, boolean],
   ) {
     this.formatter = formatter;
     this.width = width;
     this.height = height;
-    this.color = [255, 255, 255];
-    this.borders = [false, false, false, false];
+    this.color = color;
+    this.borders = borders;
   }
 
   applyStylesOf(other: CellStyle | null): CellStyle {

--- a/src/core/structure/cellStyle.ts
+++ b/src/core/structure/cellStyle.ts
@@ -2,10 +2,10 @@ import Formatter from "../evaluation/formatter";
 
 export default class CellStyle {
   formatter: Formatter | null;
-  width: number;
-  height: number;
-  color: [number, number, number];
-  borders: [boolean, boolean, boolean, boolean];
+  width?: number;
+  height?: number;
+  color?: [number, number, number];
+  borders?: [boolean, boolean, boolean, boolean];
 
   constructor(
     formatter: Formatter | null = null,
@@ -17,5 +17,35 @@ export default class CellStyle {
     this.height = height;
     this.color = [255, 255, 255];
     this.borders = [false, false, false, false];
+  }
+
+  applyStylesOf(other: CellStyle | null): CellStyle {
+    if(!other) return this;
+
+    // If a style is set in other but not in this, apply it to this.
+    for(const key in this) {
+      if (other.hasOwnProperty(key)) {
+        const otherProp = Reflect.get(other, key);
+        Reflect.set(this, key, otherProp);
+      }
+    }
+
+    return this;
+  }
+
+  clearStylingSetBy(other: CellStyle | null) {
+    if(!other) return false;
+    let isEmpty = true;
+
+    // If a property is set in other, clear it from this.
+    for(const key in this) {
+      if (other.hasOwnProperty(key) && Reflect.get(other, key)) {
+        Reflect.set(this, key, undefined);
+      }
+
+      if(isEmpty && Reflect.get(this, key)) isEmpty = false;
+    }
+
+    return isEmpty;
   }
 }

--- a/src/core/structure/cellStyle.ts
+++ b/src/core/structure/cellStyle.ts
@@ -20,11 +20,11 @@ export default class CellStyle {
   }
 
   applyStylesOf(other: CellStyle | null): CellStyle {
-    if(!other) return this;
+    if (!other) return this;
 
     // If a style is set in other but not in this, apply it to this.
-    for(const key in this) {
-      if (other.hasOwnProperty(key)) {
+    for (const key in this) {
+      if (Object.prototype.hasOwnProperty.call(other, key)) {
         const otherProp = Reflect.get(other, key);
         Reflect.set(this, key, otherProp);
       }
@@ -34,16 +34,19 @@ export default class CellStyle {
   }
 
   clearStylingSetBy(other: CellStyle | null) {
-    if(!other) return false;
+    if (!other) return false;
     let isEmpty = true;
 
     // If a property is set in other, clear it from this.
-    for(const key in this) {
-      if (other.hasOwnProperty(key) && Reflect.get(other, key)) {
+    for (const key in this) {
+      if (
+        Object.prototype.hasOwnProperty.call(other, key) &&
+        Reflect.get(other, key)
+      ) {
         Reflect.set(this, key, undefined);
       }
 
-      if(isEmpty && Reflect.get(this, key)) isEmpty = false;
+      if (isEmpty && Reflect.get(this, key)) isEmpty = false;
     }
 
     return isEmpty;

--- a/src/core/structure/cellStyle.ts
+++ b/src/core/structure/cellStyle.ts
@@ -1,6 +1,7 @@
 import Formatter from "../evaluation/formatter";
+import Cloneable from "../cloneable.ts";
 
-export default class CellStyle {
+export default class CellStyle extends Cloneable<CellStyle> {
   formatter: Formatter | null;
   width?: number;
   height?: number;
@@ -14,6 +15,7 @@ export default class CellStyle {
     color?: [number, number, number],
     borders?: [boolean, boolean, boolean, boolean],
   ) {
+    super();
     this.formatter = formatter;
     this.width = width;
     this.height = height;

--- a/src/core/structure/cellStyle.ts
+++ b/src/core/structure/cellStyle.ts
@@ -26,7 +26,10 @@ export default class CellStyle {
 
     // If a style is set in other but not in this, apply it to this.
     for (const key in this) {
-      if (Object.prototype.hasOwnProperty.call(other, key)) {
+      if (
+        Object.prototype.hasOwnProperty.call(other, key) &&
+        !Reflect.get(this, key)
+      ) {
         const otherProp = Reflect.get(other, key);
         Reflect.set(this, key, otherProp);
       }

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -101,12 +101,8 @@ export default class Sheet {
     const row = this.rows.get(rowKey);
     if (!col || !row) return this.defaultStyle;
 
-    let cellStyle = col.cellFormatting.get(row.key);
-    if (!cellStyle) {
-      cellStyle = new CellStyle();
-    } else {
-      cellStyle = structuredClone(cellStyle)!;
-    }
+    const existingStyle = col.cellFormatting.get(row.key);
+    const cellStyle = new CellStyle().clone(existingStyle);
 
     // Apply style properties with priority: cell style > column style > row style > default style.
     cellStyle
@@ -126,12 +122,10 @@ export default class Sheet {
     const row = this.rows.get(rowKey);
     if (!col || !row) return false;
 
-    style = structuredClone(style)!;
     if (style == null) {
-      col.cellFormatting.delete(row.key);
-      row.cellFormatting.delete(col.key);
-      return true;
+      return this.clearStyle(colKey, rowKey);
     }
+    style = new CellStyle().clone(style);
 
     col.cellFormatting.set(row.key, style);
     row.cellFormatting.set(col.key, style);
@@ -158,7 +152,7 @@ export default class Sheet {
     group: CellGroup<ColumnKey | RowKey>,
     style: CellStyle | null,
   ) {
-    style = style ? structuredClone(style)! : null;
+    style = style ? new CellStyle().clone(style) : null;
     group.defaultStyle = style;
 
     // Iterate through cells in this column and clear any styling properties set by the new style.

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -3,6 +3,7 @@ import Cell from "./cell/cell.ts";
 import Column from "./group/column.ts";
 import Row from "./group/row.ts";
 import { PositionInfo } from "./sheet.types.ts";
+import CellStyle from "./cellStyle.ts";
 
 export default class Sheet {
   defaultStyle: any;
@@ -84,6 +85,78 @@ export default class Sheet {
 
     // TODO References should also be checked here.
 
+    return true;
+  }
+
+  getStyle(colKey: ColumnKey, rowKey: RowKey): CellStyle {
+    const col = this.columns.get(colKey);
+    const row = this.rows.get(rowKey);
+    if (!col || !row) return this.defaultStyle;
+
+    let cellStyle = col.cellFormatting.get(row.key);
+    // Return with priority: cell style > column style > row style > default style
+    cellStyle =
+      cellStyle ?? col.defaultStyle ?? row.defaultStyle ?? this.defaultStyle;
+
+    return structuredClone(cellStyle)!;
+  }
+
+  setStyle(colKey: ColumnKey, rowKey: RowKey, style: CellStyle): boolean {
+    const col = this.columns.get(colKey);
+    const row = this.rows.get(rowKey);
+    if (!col || !row) return false;
+
+    style = structuredClone(style)!;
+    col.cellFormatting.set(row.key, style);
+    row.cellFormatting.set(col.key, style);
+
+    return true;
+  }
+
+  setColumnStyle(colKey: ColumnKey, style: CellStyle): boolean {
+    const col = this.columns.get(colKey);
+    if (!col) return false;
+
+    style = structuredClone(style)!;
+    col.defaultStyle = style;
+
+    return true;
+  }
+
+  setRowStyle(rowKey: RowKey, style: CellStyle): boolean {
+    const row = this.rows.get(rowKey);
+    if (!row) return false;
+
+    style = structuredClone(style)!;
+    row.defaultStyle = style;
+
+    return true;
+  }
+
+  clearStyle(colKey: ColumnKey, rowKey: RowKey): boolean {
+    const col = this.columns.get(colKey);
+    const row = this.rows.get(rowKey);
+    if (!col || !row) return false;
+
+    col.cellFormatting.delete(row.key);
+    row.cellFormatting.delete(col.key);
+
+    return true;
+  }
+
+  clearColumnStyle(colKey: ColumnKey): boolean {
+    const col = this.columns.get(colKey);
+    if (!col) return false;
+
+    col.defaultStyle = null;
+    return true;
+  }
+
+  clearRowStyle(rowKey: RowKey): boolean {
+    const row = this.rows.get(rowKey);
+    if (!row) return false;
+
+    row.defaultStyle = null;
     return true;
   }
 

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -96,7 +96,7 @@ export default class Sheet {
     return true;
   }
 
-  getStyle(colKey: ColumnKey, rowKey: RowKey): CellStyle {
+  getCellStyle(colKey: ColumnKey, rowKey: RowKey): CellStyle {
     const col = this.columns.get(colKey);
     const row = this.rows.get(rowKey);
     if (!col || !row) return this.defaultStyle;
@@ -113,7 +113,7 @@ export default class Sheet {
     return cellStyle;
   }
 
-  setStyle(
+  setCellStyle(
     colKey: ColumnKey,
     rowKey: RowKey,
     style: CellStyle | null,
@@ -123,7 +123,7 @@ export default class Sheet {
     if (!col || !row) return false;
 
     if (style == null) {
-      return this.clearStyle(colKey, rowKey);
+      return this.clearCellStyle(colKey, rowKey);
     }
     style = new CellStyle().clone(style);
 
@@ -162,14 +162,14 @@ export default class Sheet {
 
       // The cell's style will have no properties after applying this group's new style; clear it.
       if (group instanceof Column) {
-        this.clearStyle(group.key, opposingKey as RowKey);
+        this.clearCellStyle(group.key, opposingKey as RowKey);
         continue;
       }
-      this.clearStyle(opposingKey as ColumnKey, group.key as RowKey);
+      this.clearCellStyle(opposingKey as ColumnKey, group.key as RowKey);
     }
   }
 
-  clearStyle(colKey: ColumnKey, rowKey: RowKey): boolean {
+  private clearCellStyle(colKey: ColumnKey, rowKey: RowKey): boolean {
     const col = this.columns.get(colKey);
     const row = this.rows.get(rowKey);
     if (!col || !row) return false;

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -4,6 +4,7 @@ import Column from "./group/column.ts";
 import Row from "./group/row.ts";
 import { PositionInfo } from "./sheet.types.ts";
 import CellStyle from "./cellStyle.ts";
+import CellGroup from "./group/cellGroup.ts";
 
 export default class Sheet {
   defaultStyle: any;
@@ -94,43 +95,68 @@ export default class Sheet {
     if (!col || !row) return this.defaultStyle;
 
     let cellStyle = col.cellFormatting.get(row.key);
-    // Return with priority: cell style > column style > row style > default style
-    cellStyle =
-      cellStyle ?? col.defaultStyle ?? row.defaultStyle ?? this.defaultStyle;
+    if(!cellStyle) {
+      cellStyle = new CellStyle();
+    } else {
+      cellStyle = structuredClone(cellStyle)!;
+    }
 
-    return structuredClone(cellStyle)!;
+    // Apply style properties with priority: cell style > column style > row style > default style.
+    cellStyle.applyStylesOf(col.defaultStyle).applyStylesOf(row.defaultStyle).applyStylesOf(this.defaultStyle);
+
+    return cellStyle;
   }
 
-  setStyle(colKey: ColumnKey, rowKey: RowKey, style: CellStyle): boolean {
+  setStyle(colKey: ColumnKey, rowKey: RowKey, style: CellStyle | null): boolean {
     const col = this.columns.get(colKey);
     const row = this.rows.get(rowKey);
     if (!col || !row) return false;
 
     style = structuredClone(style)!;
+    if(style == null) {
+      col.cellFormatting.delete(row.key);
+      row.cellFormatting.delete(col.key);
+      return true;
+    }
+
     col.cellFormatting.set(row.key, style);
     row.cellFormatting.set(col.key, style);
-
     return true;
   }
 
-  setColumnStyle(colKey: ColumnKey, style: CellStyle): boolean {
+  setColumnStyle(colKey: ColumnKey, style: CellStyle | null): boolean {
     const col = this.columns.get(colKey);
     if (!col) return false;
 
-    style = structuredClone(style)!;
-    col.defaultStyle = style;
-
+    this.setCellGroupStyle(col, style);
     return true;
   }
 
-  setRowStyle(rowKey: RowKey, style: CellStyle): boolean {
+  setRowStyle(rowKey: RowKey, style: CellStyle | null): boolean {
     const row = this.rows.get(rowKey);
     if (!row) return false;
 
-    style = structuredClone(style)!;
-    row.defaultStyle = style;
-
+    this.setCellGroupStyle(row, style);
     return true;
+  }
+
+  private setCellGroupStyle(group: CellGroup<ColumnKey | RowKey>, style: CellStyle | null) {
+    style = style ? structuredClone(style)! : null;
+    group.defaultStyle = style;
+
+    // Iterate through cells in this column and clear any styling properties set by the new style.
+    for (const [opposingKey, cellStyle] of group.cellFormatting) {
+      const shouldClear = cellStyle.clearStylingSetBy(style);
+      if(!shouldClear) continue;
+
+      // The cell's style will have no properties after applying this group's new style; clear it.
+      if(group instanceof Column)
+      {
+        this.clearStyle(group.key, opposingKey as RowKey)
+        continue;
+      }
+      this.clearStyle(opposingKey as ColumnKey, group.key as RowKey)
+    }
   }
 
   clearStyle(colKey: ColumnKey, rowKey: RowKey): boolean {
@@ -141,22 +167,6 @@ export default class Sheet {
     col.cellFormatting.delete(row.key);
     row.cellFormatting.delete(col.key);
 
-    return true;
-  }
-
-  clearColumnStyle(colKey: ColumnKey): boolean {
-    const col = this.columns.get(colKey);
-    if (!col) return false;
-
-    col.defaultStyle = null;
-    return true;
-  }
-
-  clearRowStyle(rowKey: RowKey): boolean {
-    const row = this.rows.get(rowKey);
-    if (!row) return false;
-
-    row.defaultStyle = null;
     return true;
   }
 

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -19,7 +19,14 @@ export default class Sheet {
   default_height: number;
 
   constructor() {
-    this.defaultStyle = null;
+    this.defaultStyle = new CellStyle(
+      null,
+      30,
+      10,
+      [0, 0, 0],
+      [false, false, false, false],
+    ); // TODO This should be configurable.
+
     this.settings = null;
     this.cell_data = new Map<CellKey, Cell>();
     this.rows = new Map<RowKey, Row>();

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -55,32 +55,6 @@ export default class Sheet {
     };
   }
 
-  private createCell(colKey: ColumnKey, rowKey: RowKey, value: string): Cell {
-    const col = this.columns.get(colKey);
-    const row = this.rows.get(rowKey);
-    if (!col || !row) {
-      throw new Error(
-        `Failed to create cell at col: ${col} row: ${row}: Column or Row not found.`,
-      );
-    }
-
-    if (col.cellIndex.has(row.key)) {
-      throw new Error(
-        `Failed to create cell at col: ${col} row: ${row}: Cell already exists.`,
-      );
-    }
-
-    const cell = new Cell();
-    cell.formula = value;
-    this.cell_data.set(cell.key, cell);
-    this.resolveCell(cell);
-
-    col.cellIndex.set(row.key, cell.key);
-    row.cellIndex.set(col.key, cell.key);
-
-    return cell;
-  }
-
   deleteCell(colKey: ColumnKey, rowKey: RowKey): boolean {
     const col = this.columns.get(colKey);
     const row = this.rows.get(rowKey);
@@ -113,17 +87,6 @@ export default class Sheet {
     return true;
   }
 
-  private getCell(colKey: ColumnKey, rowKey: RowKey): Cell | null {
-    const col = this.columns.get(colKey);
-    const row = this.rows.get(rowKey);
-
-    if (!col || !row) return null;
-
-    if (!col.cellIndex.has(row.key)) return null;
-    const cellKey = col.cellIndex.get(row.key)!;
-    return this.cell_data.get(cellKey)!;
-  }
-
   // <Row index, <Column index, value>>
   exportData(): Map<number, Map<number, string>> {
     const data = new Map<number, Map<number, string>>();
@@ -143,6 +106,43 @@ export default class Sheet {
     }
 
     return data;
+  }
+
+  private createCell(colKey: ColumnKey, rowKey: RowKey, value: string): Cell {
+    const col = this.columns.get(colKey);
+    const row = this.rows.get(rowKey);
+    if (!col || !row) {
+      throw new Error(
+        `Failed to create cell at col: ${col} row: ${row}: Column or Row not found.`,
+      );
+    }
+
+    if (col.cellIndex.has(row.key)) {
+      throw new Error(
+        `Failed to create cell at col: ${col} row: ${row}: Cell already exists.`,
+      );
+    }
+
+    const cell = new Cell();
+    cell.formula = value;
+    this.cell_data.set(cell.key, cell);
+    this.resolveCell(cell);
+
+    col.cellIndex.set(row.key, cell.key);
+    row.cellIndex.set(col.key, cell.key);
+
+    return cell;
+  }
+
+  private getCell(colKey: ColumnKey, rowKey: RowKey): Cell | null {
+    const col = this.columns.get(colKey);
+    const row = this.rows.get(rowKey);
+
+    if (!col || !row) return null;
+
+    if (!col.cellIndex.has(row.key)) return null;
+    const cellKey = col.cellIndex.get(row.key)!;
+    return this.cell_data.get(cellKey)!;
   }
 
   private resolveCell(cell: Cell) {

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -95,25 +95,32 @@ export default class Sheet {
     if (!col || !row) return this.defaultStyle;
 
     let cellStyle = col.cellFormatting.get(row.key);
-    if(!cellStyle) {
+    if (!cellStyle) {
       cellStyle = new CellStyle();
     } else {
       cellStyle = structuredClone(cellStyle)!;
     }
 
     // Apply style properties with priority: cell style > column style > row style > default style.
-    cellStyle.applyStylesOf(col.defaultStyle).applyStylesOf(row.defaultStyle).applyStylesOf(this.defaultStyle);
+    cellStyle
+      .applyStylesOf(col.defaultStyle)
+      .applyStylesOf(row.defaultStyle)
+      .applyStylesOf(this.defaultStyle);
 
     return cellStyle;
   }
 
-  setStyle(colKey: ColumnKey, rowKey: RowKey, style: CellStyle | null): boolean {
+  setStyle(
+    colKey: ColumnKey,
+    rowKey: RowKey,
+    style: CellStyle | null,
+  ): boolean {
     const col = this.columns.get(colKey);
     const row = this.rows.get(rowKey);
     if (!col || !row) return false;
 
     style = structuredClone(style)!;
-    if(style == null) {
+    if (style == null) {
       col.cellFormatting.delete(row.key);
       row.cellFormatting.delete(col.key);
       return true;
@@ -140,22 +147,24 @@ export default class Sheet {
     return true;
   }
 
-  private setCellGroupStyle(group: CellGroup<ColumnKey | RowKey>, style: CellStyle | null) {
+  private setCellGroupStyle(
+    group: CellGroup<ColumnKey | RowKey>,
+    style: CellStyle | null,
+  ) {
     style = style ? structuredClone(style)! : null;
     group.defaultStyle = style;
 
     // Iterate through cells in this column and clear any styling properties set by the new style.
     for (const [opposingKey, cellStyle] of group.cellFormatting) {
       const shouldClear = cellStyle.clearStylingSetBy(style);
-      if(!shouldClear) continue;
+      if (!shouldClear) continue;
 
       // The cell's style will have no properties after applying this group's new style; clear it.
-      if(group instanceof Column)
-      {
-        this.clearStyle(group.key, opposingKey as RowKey)
+      if (group instanceof Column) {
+        this.clearStyle(group.key, opposingKey as RowKey);
         continue;
       }
-      this.clearStyle(opposingKey as ColumnKey, group.key as RowKey)
+      this.clearStyle(opposingKey as ColumnKey, group.key as RowKey);
     }
   }
 


### PR DESCRIPTION
Closes #36 
* Implement `getStyle` for accessing `CellStyle` for a cell by `ColumnKey` and `RowKey`
* Implement merging CellStyles
    * If for example a cell defines font color and its column defines background color, we want to return a style object with both of these properties from `getStyle`
* Add setters and clear methods for cell, column and row `CellStyle`
* Reorganize methods
* Fix some linting configuration issues