### PR TITLE
Integrate math.js and implement cell reference resolving

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import Lightsheet from "./src/main.ts";
 var data = [
-  ["1", "=1+2/3*6", "img/nophoto.jpg", "Marketing", "3120"],
+  ["1", "=1+2/3*6+A1", "img/nophoto.jpg", "Marketing", "3120"],
   ["2", "Jorge", "img/nophoto.jpg", "Marketing", "3120"],
   ["3", "Jorge", "img/nophoto.jpg", "Marketing", "3120"],
 ];

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import Lightsheet from "./src/main.ts";
 var data = [
-  ["1", "=1+2/3*6+A1", "img/nophoto.jpg", "Marketing", "3120"],
+  ["1", "=1+2/3*6+A1+test(1,2)", "img/nophoto.jpg", "Marketing", "3120"],
   ["2", "Jorge", "img/nophoto.jpg", "Marketing", "3120"],
   ["3", "Jorge", "img/nophoto.jpg", "Marketing", "3120"],
 ];

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 import Lightsheet from "./src/main.ts";
 var data = [
-  [1, "", "img/nophoto.jpg", "Marketing", "3120"],
-  [2, "Jorge", "img/nophoto.jpg", "Marketing", "3120"],
-  [3, "Jorge", "img/nophoto.jpg", "Marketing", "3120"],
+  ["1", "=1+2/3*6", "img/nophoto.jpg", "Marketing", "3120"],
+  ["2", "Jorge", "img/nophoto.jpg", "Marketing", "3120"],
+  ["3", "Jorge", "img/nophoto.jpg", "Marketing", "3120"],
 ];
 const columns = [
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vite-project",
       "version": "0.0.1",
       "dependencies": {
+        "mathjs": "^12.4.0",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -29,6 +30,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.0.tgz",
+      "integrity": "sha512-Chk32uHMg6TnQdvw2e9IlqPpFX/6NLuK0Ys2PqLb7/gL5uFn9mXvK715FGLlOLQrcO4qIkNHkvPGktzzXexsFw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1114,6 +1126,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/complex.js": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.1.1.tgz",
+      "integrity": "sha512-8njCHOTtFFLtegk6zQo0kkVX1rngygb/KQI6z1qZxlFI3scluC+LVTCFbrkWjBv4vvLlbQ9t88IPMC6k95VTTg==",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/infusion"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1150,6 +1174,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -1218,6 +1247,11 @@
         "@esbuild/win32-ia32": "0.19.12",
         "@esbuild/win32-x64": "0.19.12"
       }
+    },
+    "node_modules/escape-latex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
+      "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw=="
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -1558,6 +1592,18 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
+    "node_modules/fraction.js": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.4.tgz",
+      "integrity": "sha512-pwiTgt0Q7t+GHZA4yaLjObx4vXmmdcS0iSJ19o8d/goUGgItX9UZWKWNnLHehxviD8wU2IWRsnR8cD5+yOJP2Q==",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1777,6 +1823,11 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw=="
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -1860,6 +1911,28 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/mathjs": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-12.4.0.tgz",
+      "integrity": "sha512-4Moy0RNjwMSajEkGGxNUyMMC/CZAcl87WBopvNsJWB4E4EFebpTedr+0/rhqmnOSTH3Wu/3WfiWiw6mqiaHxVw==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "complex.js": "^2.1.1",
+        "decimal.js": "^10.4.3",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "4.3.4",
+        "javascript-natural-sort": "^0.7.1",
+        "seedrandom": "^3.0.5",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^4.1.1"
+      },
+      "bin": {
+        "mathjs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/merge2": {
@@ -2144,6 +2217,11 @@
         }
       ]
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2232,6 +2310,11 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
     },
     "node_modules/semver": {
       "version": "7.6.0",
@@ -2345,6 +2428,11 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2397,6 +2485,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-function": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.1.1.tgz",
+      "integrity": "sha512-Pq1DVubcvibmm8bYcMowjVnnMwPVMeh0DIdA8ad8NZY2sJgapANJmiigSUwlt+EgXxpfIv8MWrQXTIzkfYZLYQ==",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "vite": "^5.1.0"
   },
   "dependencies": {
+    "mathjs": "^12.4.0",
     "uuid": "^9.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
     "build:watch": "tsc && vite build --watch"
   },
   "devDependencies": {
+    "@types/uuid": "^9.0.8",
     "@typescript-eslint/eslint-plugin": "^7.0.2",
     "@typescript-eslint/parser": "^7.0.2",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "prettier": "^3.2.5",
-    "@types/uuid": "^9.0.8",
     "typescript": "^5.2.2",
     "vite": "^5.1.0"
   },

--- a/src/core/evaluation/expressionHandler.ts
+++ b/src/core/evaluation/expressionHandler.ts
@@ -34,11 +34,15 @@ export default class ExpressionHandler {
       this.resolveSymbol(name);
   }
 
-  evaluate(expression: string): string {
+  evaluate(expression: string): string | null {
     if (!expression.startsWith("=")) return expression;
     expression = expression.substring(1);
-    const parsed = math.parse(expression);
-    return parsed.evaluate();
+    try {
+      const parsed = math.parse(expression);
+      return parsed.evaluate();
+    } catch (e) {
+      return null;
+    }
   }
 
   private resolveFunction(name: string): any {

--- a/src/core/evaluation/expressionHandler.ts
+++ b/src/core/evaluation/expressionHandler.ts
@@ -1,12 +1,63 @@
-import { parse } from "mathjs";
+import { FunctionNode, parse, SymbolNode } from "mathjs";
+import Sheet from "../structure/sheet.ts";
 
 export default class ExpressionHandler {
-  static evaluate(expression: string): string {
+  sheet: Sheet;
+
+  constructor(sheet: Sheet) {
+    this.sheet = sheet; // TODO The scope of this class should be all sheets, not just one.
+
+    // Add our symbol resolving methods to mathjs.
+    FunctionNode.onUndefinedFunction = (name: string) =>
+      this.resolveFunction(name);
+
+    SymbolNode.onUndefinedSymbol = (name: string) => this.resolveSymbol(name);
+  }
+
+  evaluate(expression: string): string {
     if (!expression.startsWith("=")) return expression;
     expression = expression.substring(1);
-
     const parsed = parse(expression);
-    const evaluated = parsed.evaluate(); // TODO This will crash on unexpected symbols.
-    return evaluated;
+    return parsed.evaluate();
+  }
+
+  private resolveFunction(name: string): any {
+    console.log("Undefined function: " + name);
+    return this.dummyFunction; // TODO Implement defining custom functions and look up the handle here.
+  }
+
+  private dummyFunction(): any {
+    return "";
+  }
+
+  private resolveSymbol(name: string): string {
+    // Symbols should always be cell references in our case.
+    // TODO only handling references within one sheet for now.
+    const split = name.split(/[0-9]+/);
+    if (split.length <= 1) return "";
+
+    // Resolve column/row indices from text-based cell reference.
+    const columnStr = split[0];
+    const rowStr = name.substring(columnStr[0].length);
+    const columnIndex = ExpressionHandler.resolveColumnIndex(columnStr);
+    if (columnIndex == -1) return "";
+    const rowIndex = parseInt(rowStr) - 1;
+
+    return this.sheet.getCellValueAt(columnIndex, rowIndex);
+  }
+
+  // TODO Translating between column names and indices should probably be a common function.
+  private static resolveColumnIndex(column: string): number {
+    let index = 0;
+    for (let i = 0; i < column.length; i++) {
+      if (column[i] < "A" || column[i] > "Z") return -1;
+      let baseIndex = column.charCodeAt(i) - "A".charCodeAt(0);
+      if (i != column.length - 1) baseIndex += 1;
+      // Character index gives us the exponent: for example, 'AAB' is 26^2 * 1 + 26^1 * 1 + 26^0 * 1 + 1
+      const exp = column.length - i - 1;
+      index += baseIndex * Math.pow(26, exp);
+    }
+
+    return index;
   }
 }

--- a/src/core/evaluation/expressionHandler.ts
+++ b/src/core/evaluation/expressionHandler.ts
@@ -58,16 +58,18 @@ export default class ExpressionHandler {
     // Symbols should always be cell references in our case.
     // TODO only handling references within one sheet for now.
     const split = name.split(/[0-9]+/);
-    if (split.length <= 1) return "";
+    if (split.length != 2) throw new Error("Invalid symbol: " + name);
 
     // Resolve column/row indices from text-based cell reference.
     const columnStr = split[0];
-    const rowStr = name.substring(columnStr[0].length);
+    const rowStr = name.substring(columnStr.length);
     const columnIndex = ExpressionHandler.resolveColumnIndex(columnStr);
-    if (columnIndex == -1) return "";
+    if (columnIndex == -1) throw new Error("Invalid symbol: " + name);
     const rowIndex = parseInt(rowStr) - 1;
 
-    return this.sheet.getCellValueAt(columnIndex, rowIndex);
+    const value = this.sheet.getCellValueAt(columnIndex, rowIndex);
+    if (value == null) throw new Error("Invalid cell reference: " + name)
+    return value;
   }
 
   // TODO Translating between column names and indices should probably be a common function.

--- a/src/core/evaluation/expressionHandler.ts
+++ b/src/core/evaluation/expressionHandler.ts
@@ -68,7 +68,7 @@ export default class ExpressionHandler {
     const rowIndex = parseInt(rowStr) - 1;
 
     const value = this.sheet.getCellValueAt(columnIndex, rowIndex);
-    if (value == null) throw new Error("Invalid cell reference: " + name)
+    if (value == null) throw new Error("Invalid cell reference: " + name);
     return value;
   }
 

--- a/src/core/evaluation/expressionHandler.ts
+++ b/src/core/evaluation/expressionHandler.ts
@@ -1,5 +1,24 @@
-import { FunctionNode, parse, SymbolNode } from "mathjs";
+import {
+  create,
+  parseDependencies,
+  addDependencies,
+  subtractDependencies,
+  multiplyDependencies,
+  divideDependencies,
+  SymbolNodeDependencies,
+  FunctionNodeDependencies,
+} from "mathjs/number";
+
 import Sheet from "../structure/sheet.ts";
+const math = create({
+  parseDependencies,
+  addDependencies,
+  subtractDependencies,
+  multiplyDependencies,
+  divideDependencies,
+  SymbolNodeDependencies,
+  FunctionNodeDependencies,
+});
 
 export default class ExpressionHandler {
   sheet: Sheet;
@@ -8,16 +27,17 @@ export default class ExpressionHandler {
     this.sheet = sheet; // TODO The scope of this class should be all sheets, not just one.
 
     // Add our symbol resolving methods to mathjs.
-    FunctionNode.onUndefinedFunction = (name: string) =>
+    math.FunctionNode.onUndefinedFunction = (name: string) =>
       this.resolveFunction(name);
 
-    SymbolNode.onUndefinedSymbol = (name: string) => this.resolveSymbol(name);
+    math.SymbolNode.onUndefinedSymbol = (name: string) =>
+      this.resolveSymbol(name);
   }
 
   evaluate(expression: string): string {
     if (!expression.startsWith("=")) return expression;
     expression = expression.substring(1);
-    const parsed = parse(expression);
+    const parsed = math.parse(expression);
     return parsed.evaluate();
   }
 

--- a/src/core/evaluation/expressionHandler.ts
+++ b/src/core/evaluation/expressionHandler.ts
@@ -1,0 +1,5 @@
+export default class ExpressionHandler {
+  static evaluate(expression: string): string {
+    return expression;
+  }
+}

--- a/src/core/evaluation/expressionHandler.ts
+++ b/src/core/evaluation/expressionHandler.ts
@@ -1,5 +1,12 @@
+import { parse } from "mathjs";
+
 export default class ExpressionHandler {
   static evaluate(expression: string): string {
-    return expression;
+    if (!expression.startsWith("=")) return expression;
+    expression = expression.substring(1);
+
+    const parsed = parse(expression);
+    const evaluated = parsed.evaluate(); // TODO This will crash on unexpected symbols.
+    return evaluated;
   }
 }

--- a/src/core/structure/cell/cell.ts
+++ b/src/core/structure/cell/cell.ts
@@ -12,7 +12,7 @@ export default class Cell {
     this.key = generateCellKey();
     this.formula = "";
     this.value = "";
-    this.state = CellState.CELL_OK;
+    this.state = CellState.OK;
     this.referencesIn = [];
     this.referencesOut = [];
   }
@@ -20,5 +20,7 @@ export default class Cell {
 
 // Initial structure, move to separate file
 export enum CellState {
-  CELL_OK,
+  OK,
+  INVALID_EXPRESSION,
+  INVALID_FORMAT,
 }

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -72,13 +72,13 @@ export default class Sheet {
     };
   }
 
-  public getCellValueAt(colPos: number, rowPos: number): string {
+  public getCellValueAt(colPos: number, rowPos: number): string | null {
     const colKey = this.columnPositions.get(colPos);
     const rowKey = this.rowPositions.get(rowPos);
-    if (!colKey || !rowKey) return "";
+    if (!colKey || !rowKey) return null;
 
     const cell = this.getCell(colKey, rowKey);
-    return cell ? cell.value : "";
+    return cell ? cell.value : null;
   }
 
   deleteCell(colKey: ColumnKey, rowKey: RowKey): boolean {

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -17,6 +17,8 @@ export default class Sheet {
   default_width: number;
   default_height: number;
 
+  private expressionHandler: ExpressionHandler;
+
   constructor() {
     this.defaultStyle = null;
     this.settings = null;
@@ -29,6 +31,8 @@ export default class Sheet {
 
     this.default_width = 40;
     this.default_height = 20;
+
+    this.expressionHandler = new ExpressionHandler(this);
   }
 
   setCellAt(colPos: number, rowPos: number, value: string): CellInfo {
@@ -57,6 +61,15 @@ export default class Sheet {
         columnKey: this.columns.has(colKey) ? colKey : undefined,
       },
     };
+  }
+
+  public getCellValueAt(colPos: number, rowPos: number): string {
+    const colKey = this.columnPositions.get(colPos);
+    const rowKey = this.rowPositions.get(rowPos);
+    if (!colKey || !rowKey) return "";
+
+    const cell = this.getCell(colKey, rowKey);
+    return cell ? cell.value : "";
   }
 
   private createCell(colKey: ColumnKey, rowKey: RowKey, value: string): Cell {
@@ -149,7 +162,7 @@ export default class Sheet {
   }
 
   private resolveCell(cell: Cell): boolean {
-    const value = ExpressionHandler.evaluate(cell.formula);
+    const value = this.expressionHandler.evaluate(cell.formula);
     if (!value) {
       cell.state = CellState.INVALID_EXPRESSION;
       return false;

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -1,8 +1,9 @@
 import { CellKey, ColumnKey, RowKey } from "./key/keyTypes.ts";
-import Cell from "./cell/cell.ts";
+import Cell, { CellState } from "./cell/cell.ts";
 import Column from "./group/column.ts";
 import Row from "./group/row.ts";
 import { PositionInfo } from "./sheet.types.ts";
+import ExpressionHandler from "../evaluation/expressionHandler.ts";
 
 export default class Sheet {
   defaultStyle: any;
@@ -145,8 +146,18 @@ export default class Sheet {
     return data;
   }
 
-  private resolveCell(cell: Cell) {
-    cell.value = cell.formula; // TODO
+  private resolveCell(cell: Cell): boolean {
+    const value = ExpressionHandler.evaluate(cell.value);
+    if (!value) {
+      cell.state = CellState.INVALID_EXPRESSION;
+      return false;
+    }
+
+    // this.getStyle...
+
+    cell.state = CellState.OK;
+    cell.value = value;
+    return true;
   }
 
   private initializePosition(colPos: number, rowPos: number): PositionInfo {

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -218,7 +218,7 @@ export default class Sheet {
     return data;
   }
 
-    private createCell(colKey: ColumnKey, rowKey: RowKey, value: string): Cell {
+  private createCell(colKey: ColumnKey, rowKey: RowKey, value: string): Cell {
     const col = this.columns.get(colKey);
     const row = this.rows.get(rowKey);
     if (!col || !row) {

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -256,7 +256,7 @@ export default class Sheet {
 
   private resolveCell(cell: Cell): boolean {
     const value = this.expressionHandler.evaluate(cell.formula);
-    if (!value) {
+    if (value == null) {
       cell.state = CellState.INVALID_EXPRESSION;
       return false;
     }

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -168,7 +168,7 @@ export default class Sheet {
       return false;
     }
 
-    // this.getStyle...
+    // TODO Resolve restrictions from cell formatting here (CellState.INVALID_FORMAT).
 
     cell.state = CellState.OK;
     cell.value = value;

--- a/src/core/structure/sheet.types.ts
+++ b/src/core/structure/sheet.types.ts
@@ -4,3 +4,8 @@ export type PositionInfo = {
   columnKey?: ColumnKey;
   rowKey?: RowKey;
 };
+
+export type CellInfo = {
+  position: PositionInfo;
+  value?: string;
+};

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -64,7 +64,7 @@ export default class UI {
     const rowDom = document.getElementById(rowKey);
     if (!rowDom) return;
     // TODO This method is working around duplicate IDs. (issue #47)
-    // TODO Cell formula should be preserved
+    // TODO Cell formula should be preserved. (Issue #49)
     for (let i = 0; i < rowDom.children.length; i++) {
       const cellDom = rowDom.children.item(i)!;
       if (cellDom.id == colKey) {

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -60,6 +60,20 @@ export default class UI {
       );
   }
 
+  setCellValue(value: string, rowKey: string, colKey: string) {
+    const rowDom = document.getElementById(rowKey);
+    if (!rowDom) return;
+    // TODO This method is working around duplicate IDs. (issue #47)
+    // TODO Cell formula should be preserved
+    for (let i = 0; i < rowDom.children.length; i++) {
+      const cellDom = rowDom.children.item(i)!;
+      if (cellDom.id == colKey) {
+        const inputDom = cellDom.childNodes.item(0);
+        (inputDom as HTMLInputElement).value = value;
+      }
+    }
+  }
+
   onCellValueChange(
     newValue: string,
     rowDom: Element,


### PR DESCRIPTION
* Implement resolving math expressions, limited to addition, subtraction, multiplication and division. Closes #35 
    * We should keep security in mind if we expand included functionality. Mathjs has a page on security [here](https://mathjs.org/docs/expressions/security.html).
* Modify `setCell` to update cell value in the UI if the cell's value is set to an expression
* Implement resolving cell references (e.g. `=A1+A2` -> `=1+2` -> `3`) within a single sheet
* Add ExpressionHandler as a property to `Sheet` for now. It should probably be instantiated by `SheetHolder` once we implement that structure.

Points to consider in review:
* To reflect cell formula changes, `setCellValue` was added to `render.ts`. This updates the cell's input field's value to the resolved value, which means the user can't edit the formula (#49). Is this good enough to merge?
* Math.js is limited to basic math operations. This increases the dist file size to ~247kb/53kb from ~9kb/3kb. Is this small enough, or should we consider some other solution?