### PR TITLE
Single cell selection and CSS refactoring

### DIFF
--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -94,13 +94,13 @@ export default class Sheet {
     const row = this.rows.get(rowKey);
     if (!col || !row) {
       throw new Error(
-        `Failed to create cell at col: ${col} row: ${row}: Column or Row not found.`
+        `Failed to create cell at col: ${col} row: ${row}: Column or Row not found.`,
       );
     }
 
     if (col.cellIndex.has(row.key)) {
       throw new Error(
-        `Failed to create cell at col: ${col} row: ${row}: Cell already exists.`
+        `Failed to create cell at col: ${col} row: ${row}: Cell already exists.`,
       );
     }
 

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -44,6 +44,19 @@ export default class Sheet {
     this.expressionHandler = new ExpressionHandler(this);
   }
 
+  // We have the cell key, but we need to use that to find the relevant
+  // row key and column key. And then use the, to find and return
+  // the position of the cell
+
+  getRowIndex(rowKey: RowKey): number | undefined {
+    console.log(this.rows.get(rowKey));
+    return this.rows.get(rowKey)?.position;
+  }
+
+  getColumnIndex(colKey: ColumnKey): number | undefined {
+    return this.columns.get(colKey)?.position;
+  }
+
   setCellAt(colPos: number, rowPos: number, value: string): CellInfo {
     const position = this.initializePosition(colPos, rowPos);
     return this.setCell(position.columnKey!, position.rowKey!, value);

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -89,32 +89,6 @@ export default class Sheet {
     return cell ? cell.value : null;
   }
 
-  private createCell(colKey: ColumnKey, rowKey: RowKey, value: string): Cell {
-    const col = this.columns.get(colKey);
-    const row = this.rows.get(rowKey);
-    if (!col || !row) {
-      throw new Error(
-        `Failed to create cell at col: ${col} row: ${row}: Column or Row not found.`,
-      );
-    }
-
-    if (col.cellIndex.has(row.key)) {
-      throw new Error(
-        `Failed to create cell at col: ${col} row: ${row}: Cell already exists.`,
-      );
-    }
-
-    const cell = new Cell();
-    cell.formula = value;
-    this.cell_data.set(cell.key, cell);
-    this.resolveCell(cell);
-
-    col.cellIndex.set(row.key, cell.key);
-    row.cellIndex.set(col.key, cell.key);
-
-    return cell;
-  }
-
   deleteCell(colKey: ColumnKey, rowKey: RowKey): boolean {
     const col = this.columns.get(colKey);
     const row = this.rows.get(rowKey);
@@ -250,6 +224,32 @@ export default class Sheet {
     }
 
     return data;
+  }
+
+  private createCell(colKey: ColumnKey, rowKey: RowKey, value: string): Cell {
+    const col = this.columns.get(colKey);
+    const row = this.rows.get(rowKey);
+    if (!col || !row) {
+      throw new Error(
+        `Failed to create cell at col: ${col} row: ${row}: Column or Row not found.`,
+      );
+    }
+
+    if (col.cellIndex.has(row.key)) {
+      throw new Error(
+        `Failed to create cell at col: ${col} row: ${row}: Cell already exists.`,
+      );
+    }
+
+    const cell = new Cell();
+    cell.formula = value;
+    this.cell_data.set(cell.key, cell);
+    this.resolveCell(cell);
+
+    col.cellIndex.set(row.key, cell.key);
+    row.cellIndex.set(col.key, cell.key);
+
+    return cell;
   }
 
   private getCell(colKey: ColumnKey, rowKey: RowKey): Cell | null {

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,7 @@ export default class LightSheet {
       targetElement,
       this,
       this.options.data.length,
-      this.options.data[0].length
+      this.options.data[0].length,
     );
     this.initializeData();
     if (options.onCellChange) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,6 @@ export default class LightSheet {
   options: LightSheetOptions;
   sheet: Sheet;
   onCellChange?;
-  // onCellClick?;
 
   constructor(targetElement: Element, options: LightSheetOptions) {
     this.options = options;
@@ -21,7 +20,7 @@ export default class LightSheet {
       targetElement,
       this,
       this.options.data.length,
-      this.options.data[0].length,
+      this.options.data[0].length
     );
     this.initializeData();
     if (options.onCellChange) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ export default class LightSheet {
   options: LightSheetOptions;
   sheet: Sheet;
   onCellChange?;
+  // onCellClick?;
 
   constructor(targetElement: Element, options: LightSheetOptions) {
     this.options = options;

--- a/src/main.types.ts
+++ b/src/main.types.ts
@@ -3,6 +3,7 @@ export type LightSheetOptions = {
   data: any[];
   columns: LightSheetColumn[];
   onCellChange?: (colIndex: number, rowIndex: number, value: any) => void;
+  onCellClick?: (colIndex: number, rowIndex: number) => void;
 };
 
 type LightSheetColumn = { type: string; title: string; name: string };

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -11,7 +11,7 @@ export default class UI {
   rowCount: number;
   colCount: number;
   lightSheet: LightSheet;
-  selectedCell: Number[] | undefined;
+  selectedCell: number[] | undefined;
 
   constructor(
     el: Element,
@@ -53,8 +53,10 @@ export default class UI {
 
     for (let i = 0; i < headerData.length; i++) {
       const headerCellDom = document.createElement("td");
-      headerCellDom.classList.add("lightsheet_table_header",
-                                  "lightsheet_table_td");
+      headerCellDom.classList.add(
+        "lightsheet_table_header",
+        "lightsheet_table_td",
+      );
       headerCellDom.textContent = headerData[i];
       headerRowDom.appendChild(headerCellDom);
     }
@@ -67,9 +69,11 @@ export default class UI {
     //row number
     const rowNumberCell = document.createElement("td");
     rowNumberCell.innerHTML = `${rowLabelNumber + 1}`; // Row numbers start from 1
-    rowNumberCell.classList.add("lightsheet_table_row_number",
-                                "lightsheet_table_row_cell",
-                                "lightsheet_table_td");
+    rowNumberCell.classList.add(
+      "lightsheet_table_row_number",
+      "lightsheet_table_row_cell",
+      "lightsheet_table_td",
+    );
     rowDom.appendChild(rowNumberCell); // Append the row number cell to the row
 
     return rowDom;
@@ -83,9 +87,11 @@ export default class UI {
     columnKey?: string,
   ) {
     const cellDom = document.createElement("td");
-    cellDom.classList.add("lightsheet_table_cell",
-                          "lightsheet_table_row_cell",
-                          "lightsheet_table_td");
+    cellDom.classList.add(
+      "lightsheet_table_cell",
+      "lightsheet_table_row_cell",
+      "lightsheet_table_td",
+    );
     rowDom.appendChild(cellDom);
     cellDom.id = `${colIndex}-${rowIndex}`;
     const inputDom = document.createElement("input");
@@ -108,29 +114,29 @@ export default class UI {
         rowIndex,
       );
 
-    inputDom.onfocus = (e: Event) => {
+    inputDom.onfocus = () => {
       cellDom.classList.add("lightsheet_table_selected_cell");
 
       let columnIndex: number | undefined;
       let rowIndex: number | undefined;
 
       if (!this.isUUIDv4(cellDom.id)) {
-        let x = cellDom.id.split("-");
+        const x = cellDom.id.split("-");
         columnIndex = Number(x[0]);
         rowIndex = Number(x[1]);
       } else {
-        let columnKey = cellDom.id;
-        let rowKey = cellDom.parentElement?.id;
+        const columnKey = cellDom.id;
+        const rowKey = cellDom.parentElement?.id;
 
         columnIndex = this.lightSheet.sheet.getColumnIndex(
-          generateColumnKey(columnKey!)
+          generateColumnKey(columnKey!),
         );
         rowIndex = this.lightSheet.sheet.getRowIndex(generateRowKey(rowKey!));
       }
       this.selectedCell?.push(Number(columnIndex), Number(rowIndex));
     };
 
-    inputDom.onblur = (e: Event) => {
+    inputDom.onblur = () => {
       this.selectedCell = [];
       cellDom.classList.remove("lightsheet_table_selected_cell");
     };

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -11,19 +11,19 @@ export default class UI {
   rowCount: number;
   colCount: number;
   lightSheet: LightSheet;
-  selectedCell: String;
+  selectedCell: Number[] | undefined;
 
   constructor(
     el: Element,
     lightSheet: LightSheet,
     rowCount: number,
-    colCount: number,
+    colCount: number
   ) {
     this.tableEl = el;
     this.colCount = colCount;
     this.rowCount = rowCount;
     this.lightSheet = lightSheet;
-    this.selectedCell = "";
+    this.selectedCell = [];
 
     this.tableEl.classList.add("light_sheet_table_container");
 
@@ -76,15 +76,18 @@ export default class UI {
     colIndex: number,
     rowIndex: number,
     value: any,
-    columnKey?: string,
+    columnKey?: string
   ) {
     const cellDom = document.createElement("td");
     rowDom.appendChild(cellDom);
     cellDom.id = `${colIndex}-${rowIndex}`;
     const inputDom = document.createElement("input");
     inputDom.value = "";
+
     inputDom.style.outline = "none";
     inputDom.style.backgroundColor = "transparent";
+    inputDom.style.borderStyle = "none";
+    cellDom.style.border = "2px solid #000";
 
     cellDom.appendChild(inputDom);
 
@@ -99,45 +102,37 @@ export default class UI {
         rowDom,
         cellDom,
         colIndex,
-        rowIndex,
+        rowIndex
       );
 
     inputDom.onfocus = (e: Event) => {
-      // this.selectedCell =
-      // console.log(cellDom);
-      cellDom.style.backgroundColor = "yellow";
-      let x = cellDom.id.split("-");
+      cellDom.style.borderStyle = "solid";
+      cellDom.style.margin = "0px";
+      cellDom.style.border = "2px solid blue";
 
-      console.log(x);
-      console.log(this.lightSheet.sheet.getRowIndex(generateRowKey(x[0])));
-      // console.log(
-      //   this.lightSheet.sheet.getColumnIndex(
-      //     generateColumnKey(cellDom.id.split("-")[1])
-      //   )
-      // );
+      let columnIndex: number | undefined;
+      let rowIndex: number | undefined;
+
+      if (!this.isUUIDv4(cellDom.id)) {
+        let x = cellDom.id.split("-");
+        columnIndex = Number(x[0]);
+        rowIndex = Number(x[1]);
+      } else {
+        let columnKey = cellDom.id;
+        let rowKey = cellDom.parentElement?.id;
+
+        columnIndex = this.lightSheet.sheet.getColumnIndex(
+          generateColumnKey(columnKey!)
+        );
+        rowIndex = this.lightSheet.sheet.getRowIndex(generateRowKey(rowKey!));
+      }
+      this.selectedCell?.push(Number(columnIndex), Number(rowIndex));
     };
 
     inputDom.onblur = (e: Event) => {
-      this.selectedCell = "";
-      cellDom.style.backgroundColor = "white";
+      this.selectedCell = [];
+      cellDom.style.border = "2px solid #000";
     };
-
-    cellDom.onclick = (e: Event) => {
-      // console.log("cell clicked");
-      // console.log(cellDom.id);
-      // cellDom.style.backgroundColor = "yellow";
-      // this.lightSheet.onCellClick?.(colIndex, rowIndex);
-    };
-
-    // cellDom.onfocus = (e: Event) => {
-    //   this.selectedCell = cellDom.id;
-    //   cellDom.style.backgroundColor = "yellow";
-    // };
-
-    // cellDom.onblur = (e: Event) => {
-    //   this.selectedCell = "";
-    //   cellDom.style.backgroundColor = "white";
-    // };
   }
 
   setCellValue(value: string, rowKey: string, colKey: string) {
@@ -159,7 +154,7 @@ export default class UI {
     rowDom: Element,
     cellDom: Element,
     colIndex: number,
-    rowIndex: number,
+    rowIndex: number
   ) {
     const keyParts = cellDom.id.split("-");
 
@@ -188,5 +183,11 @@ export default class UI {
 
     //fire cell onchange event to client callback
     this.lightSheet.onCellChange?.(colIndex, rowIndex, newValue);
+  }
+
+  isUUIDv4(str: string) {
+    const uuidv4Pattern =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    return uuidv4Pattern.test(str);
   }
 }

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -1,4 +1,8 @@
 import LightSheet from "../main";
+import {
+  generateColumnKey,
+  generateRowKey,
+} from "../core/structure/key/keyTypes";
 
 export default class UI {
   tableEl: Element;
@@ -7,6 +11,7 @@ export default class UI {
   rowCount: number;
   colCount: number;
   lightSheet: LightSheet;
+  selectedCell: String;
 
   constructor(
     el: Element,
@@ -18,6 +23,7 @@ export default class UI {
     this.colCount = colCount;
     this.rowCount = rowCount;
     this.lightSheet = lightSheet;
+    this.selectedCell = "";
 
     this.tableEl.classList.add("light_sheet_table_container");
 
@@ -77,6 +83,8 @@ export default class UI {
     cellDom.id = `${colIndex}-${rowIndex}`;
     const inputDom = document.createElement("input");
     inputDom.value = "";
+    inputDom.style.outline = "none";
+    inputDom.style.backgroundColor = "transparent";
 
     cellDom.appendChild(inputDom);
 
@@ -93,6 +101,43 @@ export default class UI {
         colIndex,
         rowIndex,
       );
+
+    inputDom.onfocus = (e: Event) => {
+      // this.selectedCell =
+      // console.log(cellDom);
+      cellDom.style.backgroundColor = "yellow";
+      let x = cellDom.id.split("-");
+
+      console.log(x);
+      console.log(this.lightSheet.sheet.getRowIndex(generateRowKey(x[0])));
+      // console.log(
+      //   this.lightSheet.sheet.getColumnIndex(
+      //     generateColumnKey(cellDom.id.split("-")[1])
+      //   )
+      // );
+    };
+
+    inputDom.onblur = (e: Event) => {
+      this.selectedCell = "";
+      cellDom.style.backgroundColor = "white";
+    };
+
+    cellDom.onclick = (e: Event) => {
+      // console.log("cell clicked");
+      // console.log(cellDom.id);
+      // cellDom.style.backgroundColor = "yellow";
+      // this.lightSheet.onCellClick?.(colIndex, rowIndex);
+    };
+
+    // cellDom.onfocus = (e: Event) => {
+    //   this.selectedCell = cellDom.id;
+    //   cellDom.style.backgroundColor = "yellow";
+    // };
+
+    // cellDom.onblur = (e: Event) => {
+    //   this.selectedCell = "";
+    //   cellDom.style.backgroundColor = "white";
+    // };
   }
 
   setCellValue(value: string, rowKey: string, colKey: string) {
@@ -123,7 +168,7 @@ export default class UI {
       const cell = this.lightSheet.setCellAt(
         parseInt(keyParts[0]),
         parseInt(keyParts[1]),
-        newValue,
+        newValue
       );
       // Keys will be valid as value shouldn't be empty at this point.
       rowDom.id = cell.rowKey!.toString();

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -84,11 +84,6 @@ export default class UI {
     const inputDom = document.createElement("input");
     inputDom.value = "";
 
-    inputDom.style.outline = "none";
-    inputDom.style.backgroundColor = "transparent";
-    inputDom.style.borderStyle = "none";
-    cellDom.style.border = "2px solid #000";
-
     cellDom.appendChild(inputDom);
 
     if (value) {
@@ -106,9 +101,7 @@ export default class UI {
       );
 
     inputDom.onfocus = (e: Event) => {
-      cellDom.style.borderStyle = "solid";
-      cellDom.style.margin = "0px";
-      cellDom.style.border = "2px solid blue";
+      cellDom.classList.add("light_sheet_table_selected_cell");
 
       let columnIndex: number | undefined;
       let rowIndex: number | undefined;
@@ -131,7 +124,7 @@ export default class UI {
 
     inputDom.onblur = (e: Event) => {
       this.selectedCell = [];
-      cellDom.style.border = "2px solid #000";
+      cellDom.classList.remove("light_sheet_table_selected_cell");
     };
   }
 

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -53,6 +53,8 @@ export default class UI {
 
     for (let i = 0; i < headerData.length; i++) {
       const headerCellDom = document.createElement("td");
+      headerCellDom.classList.add("light_sheet_table_header",
+                                  "light_sheet_table_td");
       headerCellDom.textContent = headerData[i];
       headerRowDom.appendChild(headerCellDom);
     }
@@ -65,7 +67,9 @@ export default class UI {
     //row number
     const rowNumberCell = document.createElement("td");
     rowNumberCell.innerHTML = `${rowLabelNumber + 1}`; // Row numbers start from 1
-    rowNumberCell.className = "light_sheet_table_row"; // Add class for styling
+    rowNumberCell.classList.add("light_sheet_table_row_number",
+                                "light_sheet_table_row_cell",
+                                "light_sheet_table_td");
     rowDom.appendChild(rowNumberCell); // Append the row number cell to the row
 
     return rowDom;
@@ -79,9 +83,13 @@ export default class UI {
     columnKey?: string,
   ) {
     const cellDom = document.createElement("td");
+    cellDom.classList.add("light_sheet_table_cell",
+                          "light_sheet_table_row_cell",
+                          "light_sheet_table_td");
     rowDom.appendChild(cellDom);
     cellDom.id = `${colIndex}-${rowIndex}`;
     const inputDom = document.createElement("input");
+    inputDom.classList.add("light_sheet_table_cell_input");
     inputDom.value = "";
 
     cellDom.appendChild(inputDom);

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -25,14 +25,14 @@ export default class UI {
     this.lightSheet = lightSheet;
     this.selectedCell = [];
 
-    this.tableEl.classList.add("light_sheet_table_container");
+    this.tableEl.classList.add("lightsheet_table_container");
 
     const lightSheetContainerDom = document.createElement("div");
-    lightSheetContainerDom.classList.add("light_sheet_table_content");
+    lightSheetContainerDom.classList.add("lightsheet_table_content");
     this.tableEl.appendChild(lightSheetContainerDom);
 
     const tableContainerDom = document.createElement("table");
-    tableContainerDom.classList.add("light_sheet_table");
+    tableContainerDom.classList.add("lightsheet_table");
     tableContainerDom.setAttribute("cellpadding", "0");
     tableContainerDom.setAttribute("cellspacing", "0");
     tableContainerDom.setAttribute("unselectable", "yes");
@@ -53,8 +53,8 @@ export default class UI {
 
     for (let i = 0; i < headerData.length; i++) {
       const headerCellDom = document.createElement("td");
-      headerCellDom.classList.add("light_sheet_table_header",
-                                  "light_sheet_table_td");
+      headerCellDom.classList.add("lightsheet_table_header",
+                                  "lightsheet_table_td");
       headerCellDom.textContent = headerData[i];
       headerRowDom.appendChild(headerCellDom);
     }
@@ -67,9 +67,9 @@ export default class UI {
     //row number
     const rowNumberCell = document.createElement("td");
     rowNumberCell.innerHTML = `${rowLabelNumber + 1}`; // Row numbers start from 1
-    rowNumberCell.classList.add("light_sheet_table_row_number",
-                                "light_sheet_table_row_cell",
-                                "light_sheet_table_td");
+    rowNumberCell.classList.add("lightsheet_table_row_number",
+                                "lightsheet_table_row_cell",
+                                "lightsheet_table_td");
     rowDom.appendChild(rowNumberCell); // Append the row number cell to the row
 
     return rowDom;
@@ -83,13 +83,13 @@ export default class UI {
     columnKey?: string,
   ) {
     const cellDom = document.createElement("td");
-    cellDom.classList.add("light_sheet_table_cell",
-                          "light_sheet_table_row_cell",
-                          "light_sheet_table_td");
+    cellDom.classList.add("lightsheet_table_cell",
+                          "lightsheet_table_row_cell",
+                          "lightsheet_table_td");
     rowDom.appendChild(cellDom);
     cellDom.id = `${colIndex}-${rowIndex}`;
     const inputDom = document.createElement("input");
-    inputDom.classList.add("light_sheet_table_cell_input");
+    inputDom.classList.add("lightsheet_table_cell_input");
     inputDom.value = "";
 
     cellDom.appendChild(inputDom);
@@ -109,7 +109,7 @@ export default class UI {
       );
 
     inputDom.onfocus = (e: Event) => {
-      cellDom.classList.add("light_sheet_table_selected_cell");
+      cellDom.classList.add("lightsheet_table_selected_cell");
 
       let columnIndex: number | undefined;
       let rowIndex: number | undefined;
@@ -132,7 +132,7 @@ export default class UI {
 
     inputDom.onblur = (e: Event) => {
       this.selectedCell = [];
-      cellDom.classList.remove("light_sheet_table_selected_cell");
+      cellDom.classList.remove("lightsheet_table_selected_cell");
     };
   }
 

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -121,9 +121,9 @@ export default class UI {
       let rowIndex: number | undefined;
 
       if (!this.isUUIDv4(cellDom.id)) {
-        const x = cellDom.id.split("-");
-        columnIndex = Number(x[0]);
-        rowIndex = Number(x[1]);
+        const cellIndices = cellDom.id.split("-");
+        columnIndex = Number(cellIndices[0]);
+        rowIndex = Number(cellIndices[1]);
       } else {
         const columnKey = cellDom.id;
         const rowKey = cellDom.parentElement?.id;

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -17,7 +17,7 @@ export default class UI {
     el: Element,
     lightSheet: LightSheet,
     rowCount: number,
-    colCount: number
+    colCount: number,
   ) {
     this.tableEl = el;
     this.colCount = colCount;
@@ -76,7 +76,7 @@ export default class UI {
     colIndex: number,
     rowIndex: number,
     value: any,
-    columnKey?: string
+    columnKey?: string,
   ) {
     const cellDom = document.createElement("td");
     rowDom.appendChild(cellDom);
@@ -102,7 +102,7 @@ export default class UI {
         rowDom,
         cellDom,
         colIndex,
-        rowIndex
+        rowIndex,
       );
 
     inputDom.onfocus = (e: Event) => {
@@ -154,7 +154,7 @@ export default class UI {
     rowDom: Element,
     cellDom: Element,
     colIndex: number,
-    rowIndex: number
+    rowIndex: number,
   ) {
     const keyParts = cellDom.id.split("-");
 
@@ -163,7 +163,7 @@ export default class UI {
       const cell = this.lightSheet.setCellAt(
         parseInt(keyParts[0]),
         parseInt(keyParts[1]),
-        newValue
+        newValue,
       );
       // Keys will be valid as value shouldn't be empty at this point.
       rowDom.id = cell.rowKey!.toString();

--- a/src/ui/render.types.ts
+++ b/src/ui/render.types.ts
@@ -1,0 +1,4 @@
+export type CellIdInfo = {
+  keyParts: string[];
+  isIndex: boolean;
+};

--- a/src/ui/ui.css
+++ b/src/ui/ui.css
@@ -80,6 +80,5 @@
 }
 
 .lightsheet_table_selected_cell {
-  background-color: green;
   border: 1px solid blue;
 }

--- a/src/ui/ui.css
+++ b/src/ui/ui.css
@@ -5,14 +5,14 @@
   --lightsheet-white: #ffffff;
 }
 
-.light_sheet_table_container {
+.lightsheet_table_container {
   display: inline-block;
   padding-right: 2px;
   box-sizing: border-box;
   outline: none;
 }
 
-.light_sheet_table_content {
+.lightsheet_table_content {
   display: inline-block;
   box-sizing: border-box;
   padding-right: 3px;
@@ -20,7 +20,7 @@
   position: relative;
 }
 
-.light_sheet_table {
+.lightsheet_table {
   border-collapse: separate;
   white-space: nowrap;
   empty-cells: show;
@@ -33,7 +33,7 @@
   border-bottom: 1px solid var(--lightsheet-silver-400);
 }
 
-.light_sheet_table_td {
+.lightsheet_table_td {
   border-top: 1px solid var(--lightsheet-silver-400);
   border-left: 1px solid var(--lightsheet-silver-400);
   border-right: 1px solid var(--lightsheet-transparent);
@@ -41,7 +41,7 @@
   box-sizing: border-box;
 }
 
-.light_sheet_table_header {
+.lightsheet_table_header {
   background-color: #f3f3f3;
   padding: 2px;
   cursor: pointer;
@@ -54,13 +54,13 @@
 }
 
 /* All td's in the table below the header row */
-.light_sheet_table_row_td {
+.lightsheet_table_row_td {
   padding: 4px;
   white-space: nowrap;
   line-height: 1em;
 }
 
-.light_sheet_table_cell_input {
+.lightsheet_table_cell_input {
   border: 0px;
   border-radius: 0px;
   outline: 0px;
@@ -72,14 +72,14 @@
   box-sizing: border-box;
 }
 
-.light_sheet_table_row_number {
+.lightsheet_table_row_number {
   position: relative;
   background-color: var(--lightsheet-gray-200);
   text-align: center;
   width: 50px;
 }
 
-.light_sheet_table_selected_cell {
+.lightsheet_table_selected_cell {
   background-color: green;
   border: 1px solid blue;
 }

--- a/src/ui/ui.css
+++ b/src/ui/ui.css
@@ -78,3 +78,8 @@
   text-align: center;
   width: 50px;
 }
+
+.light_sheet_table_selected_cell {
+  background-color: green;
+  border: 1px solid blue;
+}

--- a/src/ui/ui.css
+++ b/src/ui/ui.css
@@ -33,16 +33,18 @@
   border-bottom: 1px solid var(--lightsheet-silver-400);
 }
 
-.light_sheet_table > thead > tr > td {
+.light_sheet_table_td {
   border-top: 1px solid var(--lightsheet-silver-400);
   border-left: 1px solid var(--lightsheet-silver-400);
   border-right: 1px solid var(--lightsheet-transparent);
   border-bottom: 1px solid var(--lightsheet-transparent);
+  box-sizing: border-box;
+}
 
+.light_sheet_table_header {
   background-color: #f3f3f3;
   padding: 2px;
   cursor: pointer;
-  box-sizing: border-box;
   overflow: hidden;
   position: -webkit-sticky;
   position: sticky;
@@ -51,18 +53,14 @@
   text-align: center;
 }
 
-.light_sheet_table > tbody > tr > td {
-  border-top: 1px solid var(--lightsheet-silver-400);
-  border-left: 1px solid var(--lightsheet-silver-400);
-  border-right: 1px solid var(--lightsheet-transparent);
-  border-bottom: 1px solid var(--lightsheet-transparent);
+/* All td's in the table below the header row */
+.light_sheet_table_row_td {
   padding: 4px;
   white-space: nowrap;
-  box-sizing: border-box;
   line-height: 1em;
 }
 
-.light_sheet_table > tbody > tr > td > input {
+.light_sheet_table_cell_input {
   border: 0px;
   border-radius: 0px;
   outline: 0px;
@@ -74,7 +72,7 @@
   box-sizing: border-box;
 }
 
-.light_sheet_table > tbody > tr > td:first-child {
+.light_sheet_table_row_number {
   position: relative;
   background-color: var(--lightsheet-gray-200);
   text-align: center;


### PR DESCRIPTION
Implemented the functionality of single-cell selection.
- Created methods in sheet.ts to retrieve column and row indexes
- Added onCellClick attribute to LightSheetOptions in main.types.ts
- Refactored `ui.css` to not use CSS selectors
- Changed the CSS class name prefix from `light_sheet` to `lightsheet`

Closes #33 and #78 