### PR TITLE
Use styling map instead of individual properties in CellStyle

### DIFF
--- a/src/core/cloneable.ts
+++ b/src/core/cloneable.ts
@@ -9,12 +9,17 @@ export default abstract class Cloneable<T extends object> {
         continue;
       }
 
-      const property = Reflect.get(other, key);
+      let property: any = Reflect.get(other, key);
+
+      // Method of cloning depends on the type of the property.
       if (property instanceof Cloneable) {
-        const propObj = Object.create(property);
-        Reflect.set(this, key, propObj.clone(property));
-        continue;
+        property = Object.create(property).clone(property);
+      } else if (property instanceof Map) {
+        property = new Map(property);
+      } else if (property instanceof Array) {
+        property = [...property];
       }
+
       Reflect.set(this, key, property);
     }
 

--- a/src/core/structure/cellStyle.ts
+++ b/src/core/structure/cellStyle.ts
@@ -3,38 +3,29 @@ import Cloneable from "../cloneable.ts";
 
 export default class CellStyle extends Cloneable<CellStyle> {
   formatter: Formatter | null;
-  width?: number;
-  height?: number;
-  color?: [number, number, number];
-  borders?: [boolean, boolean, boolean, boolean];
+  styling: Map<string, string>;
 
   constructor(
+    styling: Map<string, string> | null = null,
     formatter: Formatter | null = null,
-    width?: number,
-    height?: number,
-    color?: [number, number, number],
-    borders?: [boolean, boolean, boolean, boolean],
   ) {
     super();
     this.formatter = formatter;
-    this.width = width;
-    this.height = height;
-    this.color = color;
-    this.borders = borders;
+    this.styling = new Map(styling);
   }
 
   applyStylesOf(other: CellStyle | null): CellStyle {
     if (!other) return this;
 
     // If a style is set in other but not in this, apply it to this.
-    for (const key in this) {
-      if (
-        Object.prototype.hasOwnProperty.call(other, key) &&
-        !Reflect.get(this, key)
-      ) {
-        const otherProp = Reflect.get(other, key);
-        Reflect.set(this, key, otherProp);
+    for (const [key, value] of other.styling) {
+      if (!this.styling.has(key)) {
+        this.styling.set(key, value);
       }
+    }
+
+    if (other.formatter && !this.formatter) {
+      this.formatter = Object.create(other.formatter).clone(other.formatter);
     }
 
     return this;
@@ -45,15 +36,14 @@ export default class CellStyle extends Cloneable<CellStyle> {
     let isEmpty = true;
 
     // If a property is set in other, clear it from this.
-    for (const key in this) {
-      if (
-        Object.prototype.hasOwnProperty.call(other, key) &&
-        Reflect.get(other, key)
-      ) {
-        Reflect.set(this, key, undefined);
+    for (const key in other.styling) {
+      if (this.styling.has(key)) {
+        this.styling.delete(key);
       }
 
-      if (isEmpty && Reflect.get(this, key)) isEmpty = false;
+      if (other.formatter) this.formatter = null;
+
+      if (isEmpty && (this.styling.has(key) || this.formatter)) isEmpty = false;
     }
 
     return isEmpty;

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -121,18 +121,18 @@ export default class Sheet {
     return true;
   }
 
-  getCellStyle(colKey: ColumnKey, rowKey: RowKey): CellStyle {
-    const col = this.columns.get(colKey);
-    const row = this.rows.get(rowKey);
-    if (!col || !row) return this.defaultStyle;
+  getCellStyle(colKey?: ColumnKey, rowKey?: RowKey): CellStyle {
+    const col = colKey ? this.columns.get(colKey) : null;
+    const row = rowKey ? this.rows.get(rowKey) : null;
+    if (!col && !row) return this.defaultStyle;
 
-    const existingStyle = col.cellFormatting.get(row.key);
+    const existingStyle = col && row ? col.cellFormatting.get(row.key) : null;
     const cellStyle = new CellStyle().clone(existingStyle);
 
     // Apply style properties with priority: cell style > column style > row style > default style.
     cellStyle
-      .applyStylesOf(col.defaultStyle)
-      .applyStylesOf(row.defaultStyle)
+      .applyStylesOf(col ? col.defaultStyle : null)
+      .applyStylesOf(row ? row.defaultStyle : null)
       .applyStylesOf(this.defaultStyle);
 
     return cellStyle;

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -10,14 +10,14 @@ import CellGroup from "./group/cellGroup.ts";
 export default class Sheet {
   defaultStyle: any;
   settings: any;
-  cell_data: Map<CellKey, Cell>;
+  cellData: Map<CellKey, Cell>;
   rows: Map<RowKey, Row>;
   columns: Map<ColumnKey, Column>;
   rowPositions: Map<number, RowKey>;
   columnPositions: Map<number, ColumnKey>;
 
-  default_width: number;
-  default_height: number;
+  defaultWidth: number;
+  defaultHeight: number;
 
   private expressionHandler: ExpressionHandler;
 
@@ -25,15 +25,15 @@ export default class Sheet {
     this.defaultStyle = new CellStyle(); // TODO This should be configurable.
 
     this.settings = null;
-    this.cell_data = new Map<CellKey, Cell>();
+    this.cellData = new Map<CellKey, Cell>();
     this.rows = new Map<RowKey, Row>();
     this.columns = new Map<ColumnKey, Column>();
 
     this.rowPositions = new Map<number, RowKey>();
     this.columnPositions = new Map<number, ColumnKey>();
 
-    this.default_width = 40;
-    this.default_height = 20;
+    this.defaultWidth = 40;
+    this.defaultHeight = 20;
 
     this.expressionHandler = new ExpressionHandler(this);
   }
@@ -92,7 +92,7 @@ export default class Sheet {
     const cellKey = col.cellIndex.get(row.key)!;
 
     // Delete cell data and all references to it in its column and row.
-    this.cell_data.delete(cellKey);
+    this.cellData.delete(cellKey);
 
     col.cellIndex.delete(row.key);
     col.cellFormatting.delete(row.key);
@@ -209,7 +209,7 @@ export default class Sheet {
 
       // Use row's cell index to get keys for each cell and their corresponding columns.
       for (const [colKey, cellKey] of row.cellIndex) {
-        const cell = this.cell_data.get(cellKey)!;
+        const cell = this.cellData.get(cellKey)!;
         const column = this.columns.get(colKey)!;
         rowData.set(column.position, cell.value);
       }
@@ -237,7 +237,7 @@ export default class Sheet {
 
     const cell = new Cell();
     cell.formula = value;
-    this.cell_data.set(cell.key, cell);
+    this.cellData.set(cell.key, cell);
     this.resolveCell(cell);
 
     col.cellIndex.set(row.key, cell.key);
@@ -254,7 +254,7 @@ export default class Sheet {
 
     if (!col.cellIndex.has(row.key)) return null;
     const cellKey = col.cellIndex.get(row.key)!;
-    return this.cell_data.get(cellKey)!;
+    return this.cellData.get(cellKey)!;
   }
 
   private resolveCell(cell: Cell): boolean {
@@ -277,7 +277,7 @@ export default class Sheet {
 
     // Create row and column if they don't exist yet.
     if (!this.rowPositions.has(rowPos)) {
-      const row = new Row(this.default_height, rowPos);
+      const row = new Row(this.defaultHeight, rowPos);
       this.rows.set(row.key, row);
       this.rowPositions.set(rowPos, row.key);
 
@@ -288,7 +288,7 @@ export default class Sheet {
 
     if (!this.columnPositions.has(colPos)) {
       // Create a new column
-      const col = new Column(this.default_width, colPos);
+      const col = new Column(this.defaultWidth, colPos);
       this.columns.set(col.key, col);
       this.columnPositions.set(colPos, col.key);
 

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -22,13 +22,7 @@ export default class Sheet {
   private expressionHandler: ExpressionHandler;
 
   constructor() {
-    this.defaultStyle = new CellStyle(
-      null,
-      30,
-      10,
-      [0, 0, 0],
-      [false, false, false, false],
-    ); // TODO This should be configurable.
+    this.defaultStyle = new CellStyle(); // TODO This should be configurable.
 
     this.settings = null;
     this.cell_data = new Map<CellKey, Cell>();

--- a/tests/core/structure/cellStyle.test.ts
+++ b/tests/core/structure/cellStyle.test.ts
@@ -1,0 +1,66 @@
+import Sheet from "../../../src/core/structure/sheet.ts";
+import CellStyle from "../../../src/core/structure/cellStyle.ts";
+
+describe("CellStyle", () => {
+  let sheet: Sheet;
+
+  beforeEach(() => {
+    sheet = new Sheet();
+  });
+
+  it("should apply cell styling rules that are properly combined by getCellStyle", () => {
+    const pos = sheet.setCellAt(1, 1, "test")!.position;
+    sheet.defaultStyle = new CellStyle();
+
+    const styles = [
+      new CellStyle(
+        new Map([
+          ["width", "30px"],
+          ["height", "50px"],
+        ]),
+      ),
+      new CellStyle(new Map([["width", "50px"]])),
+      new CellStyle(new Map([["color", "0xff0000"]])),
+      new CellStyle(new Map([["border", "1px solid black"]])),
+    ];
+
+    sheet.setCellStyle(pos.columnKey!, pos.rowKey!, styles[0]);
+    expect(sheet.getCellStyle(pos.columnKey!, pos.rowKey!)!).toEqual(styles[0]);
+
+    sheet.setCellStyle(pos.columnKey!, pos.rowKey!, null);
+    expect(sheet.getCellStyle(pos.columnKey!, pos.rowKey!)).toEqual(
+      sheet.defaultStyle,
+    );
+
+    sheet.setRowStyle(pos.rowKey!, styles[1]);
+    expect(sheet.getCellStyle(pos.columnKey!, pos.rowKey!)!).toEqual(styles[1]);
+
+    sheet.setColumnStyle(pos.columnKey!, styles[2]);
+    expect(sheet.getCellStyle(pos.columnKey!, pos.rowKey!)!).toEqual(
+      new CellStyle(
+        new Map([
+          ["width", "50px"],
+          ["color", "0xff0000"],
+        ]),
+      ),
+    );
+
+    sheet.setCellStyle(pos.columnKey!, pos.rowKey!, styles[3]);
+    expect(sheet.getCellStyle(pos.columnKey!, pos.rowKey!)!).toEqual(
+      new CellStyle(
+        new Map([
+          ["width", "50px"],
+          ["color", "0xff0000"],
+          ["border", "1px solid black"],
+        ]),
+      ),
+    );
+
+    sheet.setCellStyle(pos.columnKey!, pos.rowKey!, null);
+    sheet.setRowStyle(pos.rowKey!, null);
+    sheet.setColumnStyle(pos.columnKey!, null);
+    expect(sheet.getCellStyle(pos.columnKey!, pos.rowKey!)).toEqual(
+      sheet.defaultStyle,
+    );
+  });
+});

--- a/tests/core/structure/sheet.test.ts
+++ b/tests/core/structure/sheet.test.ts
@@ -15,7 +15,7 @@ describe("Sheet", () => {
 
     sheet.setCellAt(colPos, rowPos, value);
 
-    const iterator = sheet.cell_data.values();
+    const iterator = sheet.cellData.values();
     const cell = iterator.next().value;
     expect(cell).toBeInstanceOf(Cell);
     expect(cell!.formula).toBe(value);


### PR DESCRIPTION
* Modify `CellStyle` to hold all formatting rules in a <string, string> map
* Modify `getCellStyle` to allow resolving style for a column or a row (even if a cell doesn't exist)
* Add a test for resolving cell styling
* Rename properties in `Sheet` using snake_case