### PR TITLE
Implement applying cell formatting rules

### DIFF
--- a/src/core/evaluation/expressionHandler.ts
+++ b/src/core/evaluation/expressionHandler.ts
@@ -87,7 +87,7 @@ export default class ExpressionHandler {
       throw new Error("Invalid cell reference: " + name);
 
     this.cellRefCache.push(cellInfo.position);
-    return cellInfo.value!;
+    return cellInfo.resolvedValue!;
   }
 
   // TODO Translating between column names and indices should probably be a common function.

--- a/src/core/evaluation/numberFormatter.ts
+++ b/src/core/evaluation/numberFormatter.ts
@@ -1,11 +1,11 @@
 import Formatter from "./formatter.ts";
 
 export default class NumberFormatter extends Formatter {
-  digits: number;
+  decimalDigits: number;
 
   constructor(digits: number) {
     super();
-    this.digits = digits;
+    this.decimalDigits = digits;
   }
 
   format(value: string): string | null {
@@ -14,6 +14,6 @@ export default class NumberFormatter extends Formatter {
     const formatted = Number(value);
     if (isNaN(formatted)) return null;
 
-    return formatted.toFixed(this.digits).toString();
+    return formatted.toFixed(this.decimalDigits).toString();
   }
 }

--- a/src/core/evaluation/numberFormatter.ts
+++ b/src/core/evaluation/numberFormatter.ts
@@ -1,0 +1,19 @@
+import Formatter from "./formatter.ts";
+
+export default class NumberFormatter extends Formatter {
+  digits: number;
+
+  constructor(digits: number) {
+    super();
+    this.digits = digits;
+  }
+
+  format(value: string): string | null {
+    if (value === "") return "";
+
+    const formatted = Number(value);
+    if (isNaN(formatted)) return null;
+
+    return formatted.toFixed(this.digits) as string;
+  }
+}

--- a/src/core/evaluation/numberFormatter.ts
+++ b/src/core/evaluation/numberFormatter.ts
@@ -3,9 +3,9 @@ import Formatter from "./formatter.ts";
 export default class NumberFormatter extends Formatter {
   decimalDigits: number;
 
-  constructor(digits: number) {
+  constructor(decimalDigits: number) {
     super();
-    this.decimalDigits = digits;
+    this.decimalDigits = decimalDigits;
   }
 
   format(value: string): string | null {

--- a/src/core/evaluation/numberFormatter.ts
+++ b/src/core/evaluation/numberFormatter.ts
@@ -14,6 +14,6 @@ export default class NumberFormatter extends Formatter {
     const formatted = Number(value);
     if (isNaN(formatted)) return null;
 
-    return formatted.toFixed(this.digits) as string;
+    return formatted.toFixed(this.digits).toString();
   }
 }

--- a/src/core/event/events.types.ts
+++ b/src/core/event/events.types.ts
@@ -8,14 +8,14 @@ export type IndexPosition = {
 export type UISetCellPayload = {
   keyPosition?: PositionInfo;
   indexPosition?: IndexPosition;
-  formula: string;
+  rawValue: string;
 };
 
 export type CoreSetCellPayload = {
   position: PositionInfo;
   indexPosition: IndexPosition;
-  formula: string;
-  value: string;
+  rawValue: string;
+  formattedValue: string;
 
   clearCell: boolean;
   clearRow: boolean;

--- a/src/core/structure/cell/cell.ts
+++ b/src/core/structure/cell/cell.ts
@@ -4,9 +4,9 @@ import { PositionInfo } from "../sheet.types.ts";
 
 export default class Cell {
   key: CellKey;
-  rawValue: string;
-  resolvedValue: string;
-  formattedValue: string;
+  rawValue: string; // User input.
+  resolvedValue: string; // Resolved value of a formula in rawValue.
+  formattedValue: string; // resolvedValue with formatting rules applied.
   private cellState: CellState;
 
   // References in this cell's formula.

--- a/src/core/structure/cell/cell.ts
+++ b/src/core/structure/cell/cell.ts
@@ -4,8 +4,9 @@ import { PositionInfo } from "../sheet.types.ts";
 
 export default class Cell {
   key: CellKey;
-  formula: string;
-  value: string;
+  rawValue: string;
+  resolvedValue: string;
+  formattedValue: string;
   private cellState: CellState;
 
   // References in this cell's formula.
@@ -14,8 +15,9 @@ export default class Cell {
 
   constructor() {
     this.key = generateCellKey();
-    this.formula = "";
-    this.value = "";
+    this.rawValue = "";
+    this.resolvedValue = "";
+    this.formattedValue = "";
     this.cellState = CellState.OK;
     this.referencesIn = new Map<CellKey, PositionInfo>();
     this.referencesOut = new Map<CellKey, PositionInfo>();
@@ -28,7 +30,8 @@ export default class Cell {
   setState(state: CellState) {
     this.cellState = state;
     if (state != CellState.OK) {
-      this.value = "";
+      this.resolvedValue = "";
+      this.formattedValue = "";
     }
   }
 }

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -330,6 +330,8 @@ export default class Sheet {
 
     col.cellFormatting.set(row.key, style);
     row.cellFormatting.set(col.key, style);
+
+    this.resolveCell(this.getCell(colKey, rowKey)!, colKey, rowKey);
     return true;
   }
 
@@ -367,6 +369,16 @@ export default class Sheet {
         continue;
       }
       this.clearCellStyle(opposingKey as ColumnKey, group.key as RowKey);
+    }
+
+    // Re-evaluate each cell in this group to apply the new style.
+    for (const [opposingKey] of group.cellIndex) {
+      const cell = this.cellData.get(group.cellIndex.get(opposingKey)!)!;
+      if (group instanceof Column) {
+        this.resolveCell(cell, group.key, opposingKey as RowKey);
+        continue;
+      }
+      this.resolveCell(cell, opposingKey as ColumnKey, group.key as RowKey);
     }
   }
 

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -362,7 +362,7 @@ export default class Sheet {
     const formatterChanged = style?.formatter != group.defaultStyle?.formatter;
     group.defaultStyle = style;
 
-    // Iterate through cells in this column and clear any styling properties set by the new style.
+    // Iterate through formatted cells in this group and clear any styling properties set by the new style.
     for (const [opposingKey, cellStyle] of group.cellFormatting) {
       const shouldClear = cellStyle.clearStylingSetBy(style);
       if (!shouldClear) continue;
@@ -375,8 +375,9 @@ export default class Sheet {
       this.clearCellStyle(opposingKey as ColumnKey, group.key as RowKey);
     }
 
-    if (!formatterChanged) return; // Only re-resolve cells if the formatter has changed.
+    if (!formatterChanged) return;
 
+    // Update all cells in this group if a new formatter was applied.
     for (const [opposingKey] of group.cellIndex) {
       const cell = this.cellData.get(group.cellIndex.get(opposingKey)!)!;
       if (group instanceof Column) {

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -509,7 +509,7 @@ export default class Sheet {
   }
 
   /**
-   * Update reference collections of cells and emit events for all cells whose values are affected.
+   * Update reference collections of cells for all cells whose values are affected.
    */
   private handleCellReferenceChanges(
     cell: Cell,

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -464,8 +464,6 @@ export default class Sheet {
   }
 
   private resolveCell(cell: Cell, colKey: ColumnKey, rowKey: RowKey): boolean {
-    const expressionHandler = new ExpressionHandler(this, cell.formula);
-    const evalResult = expressionHandler.evaluate();
     const valueChanged = this.resolveCellFormula(cell, colKey, rowKey);
     if (valueChanged && cell.state == CellState.OK) {
       this.applyCellFormatter(cell, colKey, rowKey);
@@ -479,7 +477,8 @@ export default class Sheet {
     colKey: ColumnKey,
     rowKey: RowKey,
   ): boolean {
-    const evalResult = this.expressionHandler.evaluate(cell.rawValue);
+    const expressionHandler = new ExpressionHandler(this, cell.rawValue);
+    const evalResult = expressionHandler.evaluate();
     const prevState = cell.state;
     if (!evalResult) {
       cell.setState(CellState.INVALID_EXPRESSION);

--- a/src/core/structure/sheet.types.ts
+++ b/src/core/structure/sheet.types.ts
@@ -9,7 +9,9 @@ export type PositionInfo = {
 
 export type CellInfo = {
   position: PositionInfo;
-  value?: string;
+  rawValue?: string;
+  resolvedValue?: string;
+  formattedValue?: string;
   state?: CellState;
 };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,7 +62,7 @@ export default class LightSheet {
           const columnKeyStr = cell.position.columnKey!.toString();
 
           if (!rowDom.id) rowDom.id = rowKeyStr;
-          this.#ui.addColumn(rowDom, j, i, cell.value, columnKeyStr);
+          this.#ui.addColumn(rowDom, j, i, cell.formattedValue, columnKeyStr);
         } else {
           this.#ui.addColumn(rowDom, j, i, "");
         }

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -5,7 +5,10 @@ import {
 } from "../core/structure/key/keyTypes";
 import { CellIdInfo, SelectionContainer } from "./render.types.ts";
 import LightsheetEvent from "../core/event/event.ts";
-import { CoreSetCellPayload } from "../core/event/events.types.ts";
+import {
+  CoreSetCellPayload,
+  UISetCellPayload,
+} from "../core/event/events.types.ts";
 import EventType from "../core/event/eventType.ts";
 import LightSheetHelper from "../../utils/helpers.ts";
 
@@ -206,9 +209,9 @@ export default class UI {
   }
 
   onUICellValueChange(newValue: string, colIndex: number, rowIndex: number) {
-    const payload = {
+    const payload: UISetCellPayload = {
       indexPosition: { columnIndex: colIndex, rowIndex: rowIndex },
-      formula: newValue,
+      rawValue: newValue,
     };
     this.lightSheet.events.emit(
       new LightsheetEvent(EventType.UI_SET_CELL, payload),

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -191,7 +191,7 @@ export default class UI {
         elInfo.rowDom!,
         payload.indexPosition.columnIndex,
         payload.indexPosition.rowIndex,
-        payload.value,
+        payload.formattedValue,
         payload.position.columnKey?.toString(),
       );
     }
@@ -201,7 +201,8 @@ export default class UI {
 
     // Set cell value to resolved value from the core.
     // TODO Cell formula should be preserved. (Issue #49)
-    (elInfo.cellDom.firstChild! as HTMLInputElement).value = payload.value;
+    (elInfo.cellDom.firstChild! as HTMLInputElement).value =
+      payload.formattedValue;
   }
 
   private static getElementInfoForSetCell(payload: CoreSetCellPayload) {

--- a/tests/core/structure/cellReferences.test.ts
+++ b/tests/core/structure/cellReferences.test.ts
@@ -97,10 +97,10 @@ describe("Cell references", () => {
       [0, 2], // A3
       [1, 2], // B3
     ];
-    const refValue = sheet.getCellInfoAt(1, 2)!.value; // B3
+    const refValue = sheet.getCellInfoAt(1, 2)!.resolvedValue; // B3
     for (const c of cells) {
       const cellInfo = sheet.getCellInfoAt(c[0], c[1])!;
-      expect(cellInfo.value).toBe(refValue);
+      expect(cellInfo.resolvedValue).toBe(refValue);
     }
   });
 });

--- a/tests/core/structure/deleteColumn.test.ts
+++ b/tests/core/structure/deleteColumn.test.ts
@@ -15,23 +15,23 @@ describe("Delete column test", () => {
 
   it("Should delete column shift the other columns correctly", () => {
     sheet.deleteColumn(0);
-    expect(sheet.getCellInfoAt(0, 0)!.value).toBe("2x1");
-    expect(sheet.getCellInfoAt(1, 0)!.value).toBe("3x1");
+    expect(sheet.getCellInfoAt(0, 0)!.resolvedValue).toBe("2x1");
+    expect(sheet.getCellInfoAt(1, 0)!.resolvedValue).toBe("3x1");
     expect(sheet.getCellInfoAt(2, 0)).toBe(null);
-    expect(sheet.getCellInfoAt(0, 1)!.value).toBe("2x2");
-    expect(sheet.getCellInfoAt(1, 1)!.value).toBe("3x2");
+    expect(sheet.getCellInfoAt(0, 1)!.resolvedValue).toBe("2x2");
+    expect(sheet.getCellInfoAt(1, 1)!.resolvedValue).toBe("3x2");
     expect(sheet.getCellInfoAt(2, 1)).toBe(null);
   });
 
   it("Should delete empty column and reverse the insert operation", () => {
     sheet.insertColumn(0);
     sheet.deleteColumn(0);
-    expect(sheet.getCellInfoAt(0, 0)!.value).toBe("1x1");
-    expect(sheet.getCellInfoAt(1, 0)!.value).toBe("2x1");
-    expect(sheet.getCellInfoAt(2, 0)!.value).toBe("3x1");
-    expect(sheet.getCellInfoAt(0, 1)!.value).toBe("1x2");
-    expect(sheet.getCellInfoAt(1, 1)!.value).toBe("2x2");
-    expect(sheet.getCellInfoAt(2, 1)!.value).toBe("3x2");
+    expect(sheet.getCellInfoAt(0, 0)!.resolvedValue).toBe("1x1");
+    expect(sheet.getCellInfoAt(1, 0)!.resolvedValue).toBe("2x1");
+    expect(sheet.getCellInfoAt(2, 0)!.resolvedValue).toBe("3x1");
+    expect(sheet.getCellInfoAt(0, 1)!.resolvedValue).toBe("1x2");
+    expect(sheet.getCellInfoAt(1, 1)!.resolvedValue).toBe("2x2");
+    expect(sheet.getCellInfoAt(2, 1)!.resolvedValue).toBe("3x2");
   });
 
   it("Should delete the last column and not affect other columns", () => {
@@ -39,10 +39,10 @@ describe("Delete column test", () => {
     sheet.setCellAt(0, 1, "");
     sheet.deleteColumn(2);
     expect(sheet.getCellInfoAt(0, 0)).toBe(null);
-    expect(sheet.getCellInfoAt(1, 0)!.value).toBe("2x1");
+    expect(sheet.getCellInfoAt(1, 0)!.resolvedValue).toBe("2x1");
     expect(sheet.getCellInfoAt(2, 0)).toBe(null);
     expect(sheet.getCellInfoAt(0, 1)).toBe(null);
-    expect(sheet.getCellInfoAt(1, 1)!.value).toBe("2x2");
+    expect(sheet.getCellInfoAt(1, 1)!.resolvedValue).toBe("2x2");
     expect(sheet.getCellInfoAt(2, 1)).toBe(null);
   });
 });

--- a/tests/core/structure/deleteColumn.test.ts
+++ b/tests/core/structure/deleteColumn.test.ts
@@ -14,9 +14,7 @@ describe("Delete column test", () => {
   });
 
   it("Should delete column shift the other columns correctly", () => {
-    console.log(sheet.exportData());
     sheet.deleteColumn(0);
-    console.log(sheet.exportData());
     expect(sheet.getCellInfoAt(0, 0)!.value).toBe("2x1");
     expect(sheet.getCellInfoAt(1, 0)!.value).toBe("3x1");
     expect(sheet.getCellInfoAt(2, 0)).toBe(null);
@@ -26,10 +24,8 @@ describe("Delete column test", () => {
   });
 
   it("Should delete empty column and reverse the insert operation", () => {
-    console.log(sheet.exportData());
     sheet.insertColumn(0);
     sheet.deleteColumn(0);
-    console.log(sheet.exportData());
     expect(sheet.getCellInfoAt(0, 0)!.value).toBe("1x1");
     expect(sheet.getCellInfoAt(1, 0)!.value).toBe("2x1");
     expect(sheet.getCellInfoAt(2, 0)!.value).toBe("3x1");
@@ -41,9 +37,7 @@ describe("Delete column test", () => {
   it("Should delete the last column and not affect other columns", () => {
     sheet.setCellAt(0, 0, "");
     sheet.setCellAt(0, 1, "");
-    console.log(sheet.exportData());
     sheet.deleteColumn(2);
-    console.log(sheet.exportData());
     expect(sheet.getCellInfoAt(0, 0)).toBe(null);
     expect(sheet.getCellInfoAt(1, 0)!.value).toBe("2x1");
     expect(sheet.getCellInfoAt(2, 0)).toBe(null);

--- a/tests/core/structure/formatter.test.ts
+++ b/tests/core/structure/formatter.test.ts
@@ -1,0 +1,42 @@
+import Sheet from "../../../src/core/structure/sheet.ts";
+import CellStyle from "../../../src/core/structure/cellStyle.ts";
+import NumberFormatter from "../../../src/core/evaluation/numberFormatter.ts";
+import { CellState } from "../../../src/core/structure/cell/cellState.ts";
+
+describe("Formatter test", () => {
+  let sheet: Sheet;
+
+  beforeEach(() => {
+    sheet = new Sheet();
+    sheet.setCellAt(0, 0, "ABC"); // A1
+    sheet.setCellAt(0, 1, "12.3"); // A2
+    sheet.setCellAt(1, 0, "3,14"); // B1
+    sheet.setCellAt(1, 1, "=3/4"); // B2
+    sheet.setCellAt(2, 0, "3.14"); // C1
+    sheet.setCellAt(2, 1, "=A2"); // C2
+  });
+
+  it("Should round a fraction correctly", () => {
+    const oneDigit = new CellStyle(null, new NumberFormatter(1));
+    sheet.setColumnStyle(sheet.columnPositions.get(1)!, oneDigit);
+    expect(sheet.getCellInfoAt(1, 1)!.formattedValue).toBe("0.8");
+  });
+
+  it("Should apply two different formatting rules to the same cell value", () => {
+    const noDigits = new CellStyle(null, new NumberFormatter(0));
+    const twoDigits = new CellStyle(null, new NumberFormatter(2));
+
+    sheet.setColumnStyle(sheet.columnPositions.get(0)!, noDigits);
+    sheet.setColumnStyle(sheet.columnPositions.get(2)!, twoDigits);
+
+    expect(sheet.getCellInfoAt(0, 1)!.formattedValue).toBe("12");
+    expect(sheet.getCellInfoAt(2, 1)!.formattedValue).toBe("12.30");
+  });
+
+  it("Should format a string value as a number and result in an invalid cell state", () => {
+    const style = new CellStyle(null, new NumberFormatter(0));
+    sheet.setColumnStyle(sheet.columnPositions.get(0)!, style);
+
+    expect(sheet.getCellInfoAt(0, 0)!.state).toBe(CellState.INVALID_FORMAT);
+  });
+});

--- a/tests/core/structure/insertColumn.test.ts
+++ b/tests/core/structure/insertColumn.test.ts
@@ -14,9 +14,7 @@ describe("Insert column test", () => {
   });
 
   it("Should insert column and shift the other columns correctly", () => {
-    console.log(sheet.exportData());
     sheet.insertColumn(0);
-    console.log(sheet.exportData());
     expect(sheet.getCellInfoAt(0, 0)).toBe(null);
     expect(sheet.getCellInfoAt(1, 0)!.value).toBe("1x1");
     expect(sheet.getCellInfoAt(2, 0)!.value).toBe("2x1");

--- a/tests/core/structure/insertColumn.test.ts
+++ b/tests/core/structure/insertColumn.test.ts
@@ -16,12 +16,12 @@ describe("Insert column test", () => {
   it("Should insert column and shift the other columns correctly", () => {
     sheet.insertColumn(0);
     expect(sheet.getCellInfoAt(0, 0)).toBe(null);
-    expect(sheet.getCellInfoAt(1, 0)!.value).toBe("1x1");
-    expect(sheet.getCellInfoAt(2, 0)!.value).toBe("2x1");
-    expect(sheet.getCellInfoAt(3, 0)!.value).toBe("3x1");
+    expect(sheet.getCellInfoAt(1, 0)!.resolvedValue).toBe("1x1");
+    expect(sheet.getCellInfoAt(2, 0)!.resolvedValue).toBe("2x1");
+    expect(sheet.getCellInfoAt(3, 0)!.resolvedValue).toBe("3x1");
     expect(sheet.getCellInfoAt(0, 1)).toBe(null);
-    expect(sheet.getCellInfoAt(1, 1)!.value).toBe("1x2");
-    expect(sheet.getCellInfoAt(2, 1)!.value).toBe("2x2");
-    expect(sheet.getCellInfoAt(3, 1)!.value).toBe("3x2");
+    expect(sheet.getCellInfoAt(1, 1)!.resolvedValue).toBe("1x2");
+    expect(sheet.getCellInfoAt(2, 1)!.resolvedValue).toBe("2x2");
+    expect(sheet.getCellInfoAt(3, 1)!.resolvedValue).toBe("3x2");
   });
 });

--- a/tests/core/structure/mathResolveSymbol.test.ts
+++ b/tests/core/structure/mathResolveSymbol.test.ts
@@ -18,28 +18,28 @@ describe("Math resolve test", () => {
     sheet.setCellAt(2, 0, "=A1");
     const cellInfo = sheet.getCellInfoAt(2, 0);
     expect(cellInfo?.state).toBe(CellState.OK);
-    expect(cellInfo?.value).toBe("1");
+    expect(cellInfo?.resolvedValue).toBe("1");
   });
 
   it("should return A1+A2 value when =A1+A2", () => {
     sheet.setCellAt(2, 0, "=A1+A2");
     const cellInfo = sheet.getCellInfoAt(2, 0);
     expect(cellInfo?.state).toBe(CellState.OK);
-    expect(cellInfo?.value).toBe("4");
+    expect(cellInfo?.resolvedValue).toBe("4");
   });
 
   it("should return A1+A2 value when =sum(A1,A2)", () => {
     sheet.setCellAt(2, 0, "=sum(A1,A2)");
     const cellInfo = sheet.getCellInfoAt(2, 0);
     expect(cellInfo?.state).toBe(CellState.OK);
-    expect(cellInfo?.value).toBe("4");
+    expect(cellInfo?.resolvedValue).toBe("4");
   });
 
   it("should return A1+A2+A3 value when =sum(A1:A3)", () => {
     sheet.setCellAt(2, 0, "=sum(A1:A3)");
     const cellInfo = sheet.getCellInfoAt(2, 0);
     expect(cellInfo?.state).toBe(CellState.OK);
-    expect(cellInfo?.value).toBe("9");
+    expect(cellInfo?.resolvedValue).toBe("9");
   });
 
   //TODO: This test should be changed to return OK instead of INVALID_EXPRESSION
@@ -47,41 +47,41 @@ describe("Math resolve test", () => {
     sheet.setCellAt(2, 0, "=A11");
     const cellInfo = sheet.getCellInfoAt(2, 0);
     expect(cellInfo?.state).toBe(CellState.INVALID_EXPRESSION);
-    expect(cellInfo?.value).toBe("");
+    expect(cellInfo?.resolvedValue).toBe("");
   });
 
   it("should return invalid value when =A", () => {
     sheet.setCellAt(2, 0, "=A");
     const cellInfo = sheet.getCellInfoAt(2, 0);
     expect(cellInfo?.state).toBe(CellState.INVALID_EXPRESSION);
-    expect(cellInfo?.value).toBe("");
+    expect(cellInfo?.resolvedValue).toBe("");
   });
 
   it("should return invalid value when =A1A2", () => {
     sheet.setCellAt(2, 0, "=A1A2");
     const cellInfo = sheet.getCellInfoAt(2, 0);
     expect(cellInfo?.state).toBe(CellState.INVALID_EXPRESSION);
-    expect(cellInfo?.value).toBe("");
+    expect(cellInfo?.resolvedValue).toBe("");
   });
 
   it("should return invalid value when =A1+", () => {
     sheet.setCellAt(2, 0, "=A1+");
     const cellInfo = sheet.getCellInfoAt(2, 0);
     expect(cellInfo?.state).toBe(CellState.INVALID_EXPRESSION);
-    expect(cellInfo?.value).toBe("");
+    expect(cellInfo?.resolvedValue).toBe("");
   });
 
   it("should return invalid value when =A/2", () => {
     sheet.setCellAt(2, 0, "=A/2");
     const cellInfo = sheet.getCellInfoAt(2, 0);
     expect(cellInfo?.state).toBe(CellState.INVALID_EXPRESSION);
-    expect(cellInfo?.value).toBe("");
+    expect(cellInfo?.resolvedValue).toBe("");
   });
 
   it("should return invalid value when =%", () => {
     sheet.setCellAt(2, 0, "=%");
     const cellInfo = sheet.getCellInfoAt(2, 0);
     expect(cellInfo?.state).toBe(CellState.INVALID_EXPRESSION);
-    expect(cellInfo?.value).toBe("");
+    expect(cellInfo?.resolvedValue).toBe("");
   });
 });

--- a/tests/core/structure/moveColumn.test.ts
+++ b/tests/core/structure/moveColumn.test.ts
@@ -14,9 +14,7 @@ describe("move column test", () => {
   });
 
   it("should move column right and shift the other columns correctly", () => {
-    console.log(sheet.exportData());
     sheet.moveColumn(0, 2);
-    console.log(sheet.exportData());
     expect(sheet.getCellInfoAt(2, 0)!.value).toBe("1x1");
     expect(sheet.getCellInfoAt(0, 0)!.value).toBe("2x1");
     expect(sheet.getCellInfoAt(1, 0)!.value).toBe("3x1");
@@ -26,9 +24,7 @@ describe("move column test", () => {
   });
 
   it("should move column left and shift the other columns correctly", () => {
-    console.log(sheet.exportData());
     sheet.moveColumn(2, 0);
-    console.log(sheet.exportData());
     expect(sheet.getCellInfoAt(2, 0)!.value).toBe("2x1");
     expect(sheet.getCellInfoAt(0, 0)!.value).toBe("3x1");
     expect(sheet.getCellInfoAt(1, 0)!.value).toBe("1x1");
@@ -38,10 +34,8 @@ describe("move column test", () => {
   });
 
   it("should move an empty column around", () => {
-    console.log(sheet.exportData());
     sheet.insertColumn(0);
     sheet.moveColumn(0, 2);
-    console.log(sheet.exportData());
     expect(sheet.getCellInfoAt(0, 0)!.value).toBe("1x1");
     expect(sheet.getCellInfoAt(1, 0)!.value).toBe("2x1");
     expect(sheet.getCellInfoAt(2, 0)).toBe(null);
@@ -53,9 +47,7 @@ describe("move column test", () => {
   });
 
   it("should move column right a single column without shifting other columns", () => {
-    console.log(sheet.exportData());
     sheet.moveColumn(0, 1);
-    console.log(sheet.exportData());
     expect(sheet.getCellInfoAt(1, 0)!.value).toBe("1x1");
     expect(sheet.getCellInfoAt(0, 0)!.value).toBe("2x1");
     expect(sheet.getCellInfoAt(2, 0)!.value).toBe("3x1");

--- a/tests/core/structure/moveColumn.test.ts
+++ b/tests/core/structure/moveColumn.test.ts
@@ -15,44 +15,44 @@ describe("move column test", () => {
 
   it("should move column right and shift the other columns correctly", () => {
     sheet.moveColumn(0, 2);
-    expect(sheet.getCellInfoAt(2, 0)!.value).toBe("1x1");
-    expect(sheet.getCellInfoAt(0, 0)!.value).toBe("2x1");
-    expect(sheet.getCellInfoAt(1, 0)!.value).toBe("3x1");
-    expect(sheet.getCellInfoAt(0, 1)!.value).toBe("2x2");
-    expect(sheet.getCellInfoAt(1, 1)!.value).toBe("3x2");
-    expect(sheet.getCellInfoAt(2, 1)!.value).toBe("1x2");
+    expect(sheet.getCellInfoAt(2, 0)!.resolvedValue).toBe("1x1");
+    expect(sheet.getCellInfoAt(0, 0)!.resolvedValue).toBe("2x1");
+    expect(sheet.getCellInfoAt(1, 0)!.resolvedValue).toBe("3x1");
+    expect(sheet.getCellInfoAt(0, 1)!.resolvedValue).toBe("2x2");
+    expect(sheet.getCellInfoAt(1, 1)!.resolvedValue).toBe("3x2");
+    expect(sheet.getCellInfoAt(2, 1)!.resolvedValue).toBe("1x2");
   });
 
   it("should move column left and shift the other columns correctly", () => {
     sheet.moveColumn(2, 0);
-    expect(sheet.getCellInfoAt(2, 0)!.value).toBe("2x1");
-    expect(sheet.getCellInfoAt(0, 0)!.value).toBe("3x1");
-    expect(sheet.getCellInfoAt(1, 0)!.value).toBe("1x1");
-    expect(sheet.getCellInfoAt(0, 1)!.value).toBe("3x2");
-    expect(sheet.getCellInfoAt(1, 1)!.value).toBe("1x2");
-    expect(sheet.getCellInfoAt(2, 1)!.value).toBe("2x2");
+    expect(sheet.getCellInfoAt(2, 0)!.resolvedValue).toBe("2x1");
+    expect(sheet.getCellInfoAt(0, 0)!.resolvedValue).toBe("3x1");
+    expect(sheet.getCellInfoAt(1, 0)!.resolvedValue).toBe("1x1");
+    expect(sheet.getCellInfoAt(0, 1)!.resolvedValue).toBe("3x2");
+    expect(sheet.getCellInfoAt(1, 1)!.resolvedValue).toBe("1x2");
+    expect(sheet.getCellInfoAt(2, 1)!.resolvedValue).toBe("2x2");
   });
 
   it("should move an empty column around", () => {
     sheet.insertColumn(0);
     sheet.moveColumn(0, 2);
-    expect(sheet.getCellInfoAt(0, 0)!.value).toBe("1x1");
-    expect(sheet.getCellInfoAt(1, 0)!.value).toBe("2x1");
+    expect(sheet.getCellInfoAt(0, 0)!.resolvedValue).toBe("1x1");
+    expect(sheet.getCellInfoAt(1, 0)!.resolvedValue).toBe("2x1");
     expect(sheet.getCellInfoAt(2, 0)).toBe(null);
-    expect(sheet.getCellInfoAt(3, 0)!.value).toBe("3x1");
-    expect(sheet.getCellInfoAt(0, 1)!.value).toBe("1x2");
-    expect(sheet.getCellInfoAt(1, 1)!.value).toBe("2x2");
+    expect(sheet.getCellInfoAt(3, 0)!.resolvedValue).toBe("3x1");
+    expect(sheet.getCellInfoAt(0, 1)!.resolvedValue).toBe("1x2");
+    expect(sheet.getCellInfoAt(1, 1)!.resolvedValue).toBe("2x2");
     expect(sheet.getCellInfoAt(2, 1)).toBe(null);
-    expect(sheet.getCellInfoAt(3, 1)!.value).toBe("3x2");
+    expect(sheet.getCellInfoAt(3, 1)!.resolvedValue).toBe("3x2");
   });
 
   it("should move column right a single column without shifting other columns", () => {
     sheet.moveColumn(0, 1);
-    expect(sheet.getCellInfoAt(1, 0)!.value).toBe("1x1");
-    expect(sheet.getCellInfoAt(0, 0)!.value).toBe("2x1");
-    expect(sheet.getCellInfoAt(2, 0)!.value).toBe("3x1");
-    expect(sheet.getCellInfoAt(0, 1)!.value).toBe("2x2");
-    expect(sheet.getCellInfoAt(2, 1)!.value).toBe("3x2");
-    expect(sheet.getCellInfoAt(1, 1)!.value).toBe("1x2");
+    expect(sheet.getCellInfoAt(1, 0)!.resolvedValue).toBe("1x1");
+    expect(sheet.getCellInfoAt(0, 0)!.resolvedValue).toBe("2x1");
+    expect(sheet.getCellInfoAt(2, 0)!.resolvedValue).toBe("3x1");
+    expect(sheet.getCellInfoAt(0, 1)!.resolvedValue).toBe("2x2");
+    expect(sheet.getCellInfoAt(2, 1)!.resolvedValue).toBe("3x2");
+    expect(sheet.getCellInfoAt(1, 1)!.resolvedValue).toBe("1x2");
   });
 });

--- a/tests/core/structure/moveRow.test.ts
+++ b/tests/core/structure/moveRow.test.ts
@@ -16,9 +16,7 @@ describe("move row test", () => {
   });
 
   it("should move row right and shift the other rows correctly", () => {
-    console.log(sheet.exportData());
     sheet.moveRow(0, 2);
-    console.log(sheet.exportData());
     expect(sheet.getCellInfoAt(0, 0)!.value).toBe("1x2");
     expect(sheet.getCellInfoAt(1, 0)!.value).toBe("2x2");
 
@@ -30,9 +28,7 @@ describe("move row test", () => {
   });
 
   it("should move row left and shift the other rows correctly", () => {
-    console.log(sheet.exportData());
     sheet.moveRow(2, 0);
-    console.log(sheet.exportData());
     expect(sheet.getCellInfoAt(0, 0)!.value).toBe("1x3");
     expect(sheet.getCellInfoAt(1, 0)!.value).toBe("2x3");
 

--- a/tests/core/structure/moveRow.test.ts
+++ b/tests/core/structure/moveRow.test.ts
@@ -17,25 +17,25 @@ describe("move row test", () => {
 
   it("should move row right and shift the other rows correctly", () => {
     sheet.moveRow(0, 2);
-    expect(sheet.getCellInfoAt(0, 0)!.value).toBe("1x2");
-    expect(sheet.getCellInfoAt(1, 0)!.value).toBe("2x2");
+    expect(sheet.getCellInfoAt(0, 0)!.resolvedValue).toBe("1x2");
+    expect(sheet.getCellInfoAt(1, 0)!.resolvedValue).toBe("2x2");
 
-    expect(sheet.getCellInfoAt(0, 1)!.value).toBe("1x3");
-    expect(sheet.getCellInfoAt(1, 1)!.value).toBe("2x3");
+    expect(sheet.getCellInfoAt(0, 1)!.resolvedValue).toBe("1x3");
+    expect(sheet.getCellInfoAt(1, 1)!.resolvedValue).toBe("2x3");
 
-    expect(sheet.getCellInfoAt(0, 2)!.value).toBe("1x1");
-    expect(sheet.getCellInfoAt(1, 2)!.value).toBe("2x1");
+    expect(sheet.getCellInfoAt(0, 2)!.resolvedValue).toBe("1x1");
+    expect(sheet.getCellInfoAt(1, 2)!.resolvedValue).toBe("2x1");
   });
 
   it("should move row left and shift the other rows correctly", () => {
     sheet.moveRow(2, 0);
-    expect(sheet.getCellInfoAt(0, 0)!.value).toBe("1x3");
-    expect(sheet.getCellInfoAt(1, 0)!.value).toBe("2x3");
+    expect(sheet.getCellInfoAt(0, 0)!.resolvedValue).toBe("1x3");
+    expect(sheet.getCellInfoAt(1, 0)!.resolvedValue).toBe("2x3");
 
-    expect(sheet.getCellInfoAt(0, 1)!.value).toBe("1x1");
-    expect(sheet.getCellInfoAt(1, 1)!.value).toBe("2x1");
+    expect(sheet.getCellInfoAt(0, 1)!.resolvedValue).toBe("1x1");
+    expect(sheet.getCellInfoAt(1, 1)!.resolvedValue).toBe("2x1");
 
-    expect(sheet.getCellInfoAt(0, 2)!.value).toBe("1x2");
-    expect(sheet.getCellInfoAt(1, 2)!.value).toBe("2x2");
+    expect(sheet.getCellInfoAt(0, 2)!.resolvedValue).toBe("1x2");
+    expect(sheet.getCellInfoAt(1, 2)!.resolvedValue).toBe("2x2");
   });
 });

--- a/tests/core/structure/sheet.test.ts
+++ b/tests/core/structure/sheet.test.ts
@@ -18,6 +18,6 @@ describe("Sheet", () => {
     const iterator = sheet.cellData.values();
     const cell = iterator.next().value;
     expect(cell).toBeInstanceOf(Cell);
-    expect(cell!.formula).toBe(value);
+    expect(cell!.rawValue).toBe(value);
   });
 });


### PR DESCRIPTION
* Implement applying `Formatter` functions on cell value
* Modify `Cell` to hold its `rawValue` (previously `formula`), `resolvedValue` (previously `value`) and `formattedValue`
    * Modify other definitions to match the new naming pattern
* Fix cell not being resolved on formatter change
* Implement `NumberFormatter` as an example
* Remove `console.log` calls from tests