### PR TITLE
Improve handling of empty cells

### DIFF
--- a/src/core/evaluation/expressionHandler.ts
+++ b/src/core/evaluation/expressionHandler.ts
@@ -103,7 +103,7 @@ export default class ExpressionHandler {
       ExpressionHandler.parseSymbolToPosition(symbol);
 
     const cellInfo = this.sheet.getCellInfoAt(colIndex, rowIndex);
-    if (cellInfo == null || cellInfo.state != CellState.OK)
+    if (cellInfo && cellInfo.state != CellState.OK)
       throw new Error("Invalid cell reference: " + symbol);
 
     this.cellRefHolder.push({ columnIndex: colIndex, rowIndex: rowIndex });

--- a/src/core/evaluation/expressionHandler.ts
+++ b/src/core/evaluation/expressionHandler.ts
@@ -82,8 +82,13 @@ export default class ExpressionHandler {
     if (columnIndex == -1) throw new Error("Invalid symbol: " + name);
     const rowIndex = parseInt(rowStr) - 1;
 
-    const cellInfo = this.sheet.getCellInfoAt(columnIndex, rowIndex);
-    if (cellInfo == null || cellInfo.state != CellState.OK)
+    let cellInfo = this.sheet.getCellInfoAt(columnIndex, rowIndex);
+    if (!cellInfo) {
+      // Referring to a non-existent cell. Initialize it with an empty value.
+      cellInfo = this.sheet.setCellAt(columnIndex, rowIndex, "", true);
+    }
+
+    if (cellInfo.state != CellState.OK)
       throw new Error("Invalid cell reference: " + name);
 
     this.cellRefCache.push(cellInfo.position);

--- a/src/core/evaluation/expressionHandler.ts
+++ b/src/core/evaluation/expressionHandler.ts
@@ -10,8 +10,7 @@ import {
 } from "mathjs/number";
 
 import Sheet from "../structure/sheet.ts";
-import { PositionInfo } from "../structure/sheet.types.ts";
-import { EvaluationResult } from "./expressionHandler.types.ts";
+import { CellPosition, EvaluationResult } from "./expressionHandler.types.ts";
 
 import { CellState } from "../structure/cell/cellState.ts";
 const math = create({
@@ -27,7 +26,7 @@ const math = create({
 export default class ExpressionHandler {
   sheet: Sheet;
 
-  private cellRefCache: Array<PositionInfo>;
+  private cellRefCache: Array<CellPosition>;
 
   constructor(sheet: Sheet) {
     this.sheet = sheet; // TODO The scope of this class should be all sheets, not just one.
@@ -82,17 +81,12 @@ export default class ExpressionHandler {
     if (columnIndex == -1) throw new Error("Invalid symbol: " + name);
     const rowIndex = parseInt(rowStr) - 1;
 
-    let cellInfo = this.sheet.getCellInfoAt(columnIndex, rowIndex);
-    if (!cellInfo) {
-      // Referring to a non-existent cell. Initialize it with an empty value.
-      cellInfo = this.sheet.setCellAt(columnIndex, rowIndex, "", true);
-    }
-
-    if (cellInfo.state != CellState.OK)
+    const cellInfo = this.sheet.getCellInfoAt(columnIndex, rowIndex);
+    if (cellInfo && cellInfo.state != CellState.OK)
       throw new Error("Invalid cell reference: " + name);
 
-    this.cellRefCache.push(cellInfo.position);
-    return cellInfo.value!;
+    this.cellRefCache.push({ columnIndex: columnIndex, rowIndex: rowIndex });
+    return cellInfo?.value ?? "";
   }
 
   // TODO Translating between column names and indices should probably be a common function.

--- a/src/core/evaluation/expressionHandler.ts
+++ b/src/core/evaluation/expressionHandler.ts
@@ -124,6 +124,8 @@ export default class ExpressionHandler {
     const rowStr = symbol.substring(columnStr.length);
     const rowIndex = parseInt(rowStr) - 1;
 
+    if (isNaN(rowIndex)) throw new Error("Invalid symbol: " + symbol);
+
     return { colIndex, rowIndex };
   }
 

--- a/src/core/evaluation/expressionHandler.types.ts
+++ b/src/core/evaluation/expressionHandler.types.ts
@@ -1,6 +1,10 @@
-import { PositionInfo } from "../structure/sheet.types.ts";
+// TODO This should be a common type (Coordinate in render.types.ts, IndexPosition in events.types.ts)
+export type CellPosition = {
+  rowIndex: number;
+  columnIndex: number;
+};
 
 export type EvaluationResult = {
   value: string;
-  references: PositionInfo[];
+  references: CellPosition[];
 };

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -89,6 +89,8 @@ export default class Sheet {
     if (formula == "" && !allowEmpty) {
       this.deleteCell(colKey, rowKey);
       cell = null;
+      const deleted = this.deleteCellIfUnused(colKey, rowKey);
+      if (deleted) cell = null;
     } else {
       if (!cell) {
         cell = this.createCell(colKey, rowKey, formula);

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -65,8 +65,8 @@ export default class Sheet {
 
     let cell = this.getCell(colKey, rowKey);
 
-    if (formula == "" && !cell) return null;
-    if (!cell && formula != "") {
+    if (!cell) {
+      if (formula == "") return null;
       cell = this.createCell(colKey, rowKey, formula);
     }
 

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -268,7 +268,7 @@ export default class Sheet {
     return true;
   }
 
-  deleteCell(colKey: ColumnKey, rowKey: RowKey): boolean {
+  private deleteCell(colKey: ColumnKey, rowKey: RowKey): boolean {
     const col = this.columns.get(colKey);
     const row = this.rows.get(rowKey);
     if (!col || !row) return false;

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -67,18 +67,21 @@ export default class Sheet {
     }
 
     let cell = this.getCell(colKey, rowKey);
+
+    if (formula == "" && !cell) return null;
+    if (!cell && formula != "") {
+      cell = this.createCell(colKey, rowKey, formula);
+    }
+
+    cell!.formula = formula;
+
     const colIndex = this.getColumnIndex(colKey)!;
     const rowIndex = this.getRowIndex(rowKey)!;
-
-    if (formula == "") {
-      const deleted = this.deleteCellIfUnused(colKey, rowKey);
-      if (deleted) cell = null;
+    const deleted = this.deleteCellIfUnused(colKey, rowKey);
+    if (deleted) {
+      cell = null;
     } else {
-      if (!cell) {
-        cell = this.createCell(colKey, rowKey, formula);
-      }
-      cell.formula = formula;
-      this.resolveCell(cell, colKey, rowKey);
+      this.resolveCell(cell!, colKey, rowKey);
     }
 
     this.emitSetCellEvent(colKey, rowKey, colIndex, rowIndex, cell);

--- a/tests/core/structure/cellReferences.test.ts
+++ b/tests/core/structure/cellReferences.test.ts
@@ -106,7 +106,10 @@ describe("Cell references", () => {
 
   it("should create an empty cell with styling", () => {
     sheet.setCellAt(0, 0, "=B2");
-    sheet.setCellAt(1, 1, "", true); // B2
+
+    const colKey = sheet.columnPositions.get(1)!;
+    const rowKey = sheet.rowPositions.get(1)!;
+    sheet["createCell"](colKey, rowKey, ""); // B2
     expect(sheet.getCellInfoAt(1, 1)).not.toBeNull();
 
     sheet.setCellAt(0, 0, "");

--- a/tests/core/structure/cellReferences.test.ts
+++ b/tests/core/structure/cellReferences.test.ts
@@ -103,4 +103,33 @@ describe("Cell references", () => {
       expect(cellInfo.value).toBe(refValue);
     }
   });
+
+  it("should create an empty cell with styling", () => {
+    sheet.setCellAt(0, 0, "=B2");
+    sheet.setCellAt(1, 1, "", true); // B2
+    expect(sheet.getCellInfoAt(1, 1)).not.toBeNull();
+
+    sheet.setCellAt(0, 0, "");
+    expect(sheet.getCellInfoAt(0, 0)).toBeNull();
+
+    const b2 = sheet.getCellInfoAt(1, 1);
+    expect(b2).not.toBeNull();
+
+    // Clearing the style should result in the cell being deleted.
+    sheet.setCellStyle(b2!.position.columnKey!, b2!.position.rowKey!, null);
+    expect(sheet.getCellInfoAt(1, 1)).toBeNull();
+  });
+
+  it("should create a cell with a reference to a non-existent cell", () => {
+    const colKey = sheet.columnPositions.get(1)!;
+    const rowKey = sheet.rowPositions.get(1)!;
+    sheet.deleteCell(colKey, rowKey);
+    const cell = sheet.setCellAt(0, 0, "=B2");
+    expect(cell.state).toBe(CellState.OK);
+    expect(sheet.getCellInfoAt(1, 1)).not.toBeNull();
+
+    // Delete the reference - this should result in the referred cell being deleted.
+    sheet.setCellAt(0, 0, "123");
+    expect(sheet.getCellInfoAt(1, 1)).toBeNull();
+  });
 });

--- a/tests/core/structure/cellReferences.test.ts
+++ b/tests/core/structure/cellReferences.test.ts
@@ -1,6 +1,7 @@
 import Sheet from "../../../src/core/structure/sheet";
 import { CellState } from "../../../src/core/structure/cell/cellState.ts";
 import { CellInfo } from "../../../src/core/structure/sheet.types.ts";
+import CellStyle from "../../../src/core/structure/cellStyle.ts";
 
 describe("Cell references", () => {
   let sheet: Sheet;
@@ -105,18 +106,14 @@ describe("Cell references", () => {
   });
 
   it("should create an empty cell with styling", () => {
-    sheet.setCellAt(0, 0, "=B2");
+    const b2 = sheet.getCellInfoAt(1, 1)!;
+    sheet.setCellStyle(
+      b2.position!.columnKey!,
+      b2.position!.rowKey!,
+      new CellStyle(new Map([["width", "50px"]])),
+    );
 
-    const colKey = sheet.columnPositions.get(1)!;
-    const rowKey = sheet.rowPositions.get(1)!;
-    sheet["createCell"](colKey, rowKey, ""); // B2
-    expect(sheet.getCellInfoAt(1, 1)).not.toBeNull();
-
-    sheet.setCellAt(0, 0, "");
-    expect(sheet.getCellInfoAt(0, 0)).toBeNull();
-
-    const b2 = sheet.getCellInfoAt(1, 1);
-    expect(b2).not.toBeNull();
+    sheet.setCellAt(1, 1, "");
 
     // Clearing the style should result in the cell being deleted.
     sheet.setCellStyle(b2!.position.columnKey!, b2!.position.rowKey!, null);

--- a/tests/core/structure/cellReferences.test.ts
+++ b/tests/core/structure/cellReferences.test.ts
@@ -56,8 +56,8 @@ describe("Cell references", () => {
     // Deleting cells with references.
     const cell2pos = sheet.getCellInfoAt(1, 0)!;
     const cell4pos = sheet.getCellInfoAt(2, 0)!;
-    sheet.deleteCell(cell2pos.position.columnKey!, cell2pos.position.rowKey!);
-    sheet.deleteCell(cell4pos.position.columnKey!, cell4pos.position.rowKey!);
+    sheet.setCell(cell2pos.position.columnKey!, cell2pos.position.rowKey!, "");
+    sheet.setCell(cell4pos.position.columnKey!, cell4pos.position.rowKey!, "");
 
     expect(cells[0].referencesIn.size).toBe(0);
     expect(cells[0].referencesOut.size).toBe(0);
@@ -123,7 +123,7 @@ describe("Cell references", () => {
   it("should create a cell with a reference to a non-existent cell", () => {
     const colKey = sheet.columnPositions.get(1)!;
     const rowKey = sheet.rowPositions.get(1)!;
-    sheet.deleteCell(colKey, rowKey);
+    sheet.setCell(colKey, rowKey, "");
     const cell = sheet.setCellAt(0, 0, "=B2");
     expect(cell.state).toBe(CellState.OK);
     expect(sheet.getCellInfoAt(1, 1)).not.toBeNull();

--- a/tests/core/structure/cellReferences.test.ts
+++ b/tests/core/structure/cellReferences.test.ts
@@ -121,15 +121,12 @@ describe("Cell references", () => {
   });
 
   it("should create a cell with a reference to a non-existent cell", () => {
-    const colKey = sheet.columnPositions.get(1)!;
-    const rowKey = sheet.rowPositions.get(1)!;
-    sheet.setCell(colKey, rowKey, "");
-    const cell = sheet.setCellAt(0, 0, "=B2");
+    const cell = sheet.setCellAt(0, 0, "=B5");
     expect(cell.state).toBe(CellState.OK);
-    expect(sheet.getCellInfoAt(1, 1)).not.toBeNull();
+    expect(sheet.getCellInfoAt(1, 4)).not.toBeNull();
 
     // Delete the reference - this should result in the referred cell being deleted.
     sheet.setCellAt(0, 0, "123");
-    expect(sheet.getCellInfoAt(1, 1)).toBeNull();
+    expect(sheet.getCellInfoAt(1, 4)).toBeNull();
   });
 });

--- a/tests/core/structure/mathResolveSymbol.test.ts
+++ b/tests/core/structure/mathResolveSymbol.test.ts
@@ -42,14 +42,6 @@ describe("Math resolve test", () => {
     expect(cellInfo?.value).toBe("9");
   });
 
-  //TODO: This test should be changed to return OK instead of INVALID_EXPRESSION
-  it("should return invalid value when =A11", () => {
-    sheet.setCellAt(2, 0, "=A11");
-    const cellInfo = sheet.getCellInfoAt(2, 0);
-    expect(cellInfo?.state).toBe(CellState.INVALID_EXPRESSION);
-    expect(cellInfo?.value).toBe("");
-  });
-
   it("should return invalid value when =A", () => {
     sheet.setCellAt(2, 0, "=A");
     const cellInfo = sheet.getCellInfoAt(2, 0);


### PR DESCRIPTION
* Closes #97 
* Make formulas referring to a non-existing cell initialize the cell instead of giving an error
* Add a parameter to `setCell` and `setCellAt` for initializing an empty cell
    * Should we do this some other way? It's a bit unsafe to allow this, as creating an empty cell without incoming references may result in the cell existing for no reason
* Delete unused cells (no value, no style, no references 😢) when style is cleared or references are changed