### PR TITLE
Add interface method for defining functions for expression handling

### DIFF
--- a/src/core/evaluation/expressionHandler.ts
+++ b/src/core/evaluation/expressionHandler.ts
@@ -101,11 +101,30 @@ export default class ExpressionHandler {
     }
     const symbolNode = node as math.SymbolNode;
 
-    if (symbolNode.name !== targetSymbol) {
+    let prefix = "";
+    let symbol = symbolNode.name;
+    if (symbol.includes("!")) {
+      const parts = symbol.split("!");
+      prefix = parts[0] + "!";
+      symbol = parts[1];
+    }
+
+    if (symbol.includes(":")) {
+      const parts = symbol.split(":");
+      if (parts.length != 2) {
+        return symbolNode;
+      }
+      const newStart = parts[0] === targetSymbol ? newSymbol : parts[0];
+      const newEnd = parts[1] === targetSymbol ? newSymbol : parts[1];
+      symbolNode.name = prefix + newStart + ":" + newEnd;
       return symbolNode;
     }
 
-    symbolNode.name = newSymbol;
+    if (symbol !== targetSymbol) {
+      return symbolNode;
+    }
+
+    symbolNode.name = prefix + newSymbol;
     return symbolNode;
   }
 

--- a/src/core/evaluation/expressionHandler.ts
+++ b/src/core/evaluation/expressionHandler.ts
@@ -20,6 +20,7 @@ import {
 import { CellState } from "../structure/cell/cellState.ts";
 import LightSheetHelper from "../../utils/helpers.ts";
 import { Coordinate } from "../../utils/common.types.ts";
+import { CellReference } from "../structure/cell/types.cell.ts";
 
 const math = create({
   parseDependencies,
@@ -33,13 +34,20 @@ const math = create({
 });
 
 export default class ExpressionHandler {
+  private static functions: Map<
+    string,
+    (cellPos: CellReference, ...args: any[]) => string
+  > = new Map();
+
   private sheet: Sheet;
 
   private cellRefHolder: Array<CellSheetPosition>;
   private rawValue: string;
+  private targetCellRef: CellReference;
 
-  constructor(targetSheet: Sheet, rawValue: string) {
+  constructor(targetSheet: Sheet, targetCell: CellReference, rawValue: string) {
     this.sheet = targetSheet;
+    this.targetCellRef = targetCell;
 
     this.rawValue = rawValue;
     this.cellRefHolder = [];
@@ -64,6 +72,10 @@ export default class ExpressionHandler {
     const expression = this.rawValue.substring(1);
     try {
       const parsed = math.parse(expression);
+      parsed.transform((node) =>
+        this.injectFunctionParameter(node, this.targetCellRef),
+      );
+
       const value = parsed.evaluate().toString();
       const references = this.cellRefHolder.slice();
       this.cellRefHolder = [];
@@ -89,6 +101,25 @@ export default class ExpressionHandler {
       this.updateReferenceSymbol(node, fromSymbol, toSymbol),
     );
     return `=${transform.toString()}`;
+  }
+
+  private injectFunctionParameter(node: MathNode, cellPos: CellReference) {
+    if (node instanceof math.FunctionNode) {
+      const fName = (node as math.FunctionNode).fn.name;
+      // If the node is a custom function, inject the cell position as the first argument.
+      // This allows custom functions to access the cell invoking the function.
+      if (ExpressionHandler.functions.has(fName)) {
+        // Copy CellReference into mathjs node structure.
+        const record: Record<string, any> = {};
+        for (const key in cellPos) {
+          record[key] = new math.ConstantNode(
+            cellPos[key as keyof CellReference],
+          );
+        }
+        node.args.unshift(new math.ObjectNode(record));
+      }
+    }
+    return node;
   }
 
   private updateReferenceSymbol(
@@ -128,13 +159,23 @@ export default class ExpressionHandler {
     return symbolNode;
   }
 
-  private resolveFunction(name: string): any {
-    console.log("Undefined function: " + name);
-    return this.dummyFunction; // TODO Implement defining custom functions and look up the handle here.
+  private resolveFunction(name: string): (...args: any[]) => string {
+    const fun = ExpressionHandler.functions.get(name.toLowerCase());
+    if (!fun) {
+      console.log(
+        `Undefined function "${name}" in expression "${this.rawValue}"`,
+      );
+      return () => "";
+    }
+
+    return fun;
   }
 
-  private dummyFunction(): any {
-    return "";
+  static registerFunction(
+    name: string,
+    fun: (cellPos: CellReference, ...args: any[]) => string,
+  ) {
+    ExpressionHandler.functions.set(name.toLowerCase(), fun);
   }
 
   private resolveSymbol(symbol: string): any {

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -316,7 +316,11 @@ export default class Sheet {
       const refCell = refSheet.cellData.get(refCellKey)!;
 
       const expr = new ExpressionHandler(refSheet, refCell.rawValue);
-      refCell.rawValue = expr.updatePositionalReferences(from, to);
+      const newValue = expr.updatePositionalReferences(from, to);
+
+      // The formula may not change if the cell is being referenced indirectly through a range.
+      if (refCell.rawValue === newValue) continue;
+      refCell.rawValue = newValue;
 
       // Emit event for the rawValue change.
       refSheet.emitSetCellEvent(

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -446,10 +446,9 @@ export default class Sheet {
         rowData.set(column.position, cell.formattedValue);
       }
 
-      data.set(rowPos, rowData);
+      data.set(rowPos, new Map([...rowData.entries()].sort()));
     }
-
-    return data;
+    return new Map([...data.entries()].sort());
   }
 
   private createCell(colKey: ColumnKey, rowKey: RowKey, value: string): Cell {

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -317,6 +317,15 @@ export default class Sheet {
 
       const expr = new ExpressionHandler(refSheet, refCell.rawValue);
       refCell.rawValue = expr.updatePositionalReferences(from, to);
+
+      // Emit event for the rawValue change.
+      refSheet.emitSetCellEvent(
+        refInfo.column,
+        refInfo.row,
+        refSheet.getColumnIndex(refInfo.column)!,
+        refSheet.getRowIndex(refInfo.row)!,
+        refCell,
+      );
     }
   }
 

--- a/src/core/structure/sheet.ts
+++ b/src/core/structure/sheet.ts
@@ -315,7 +315,7 @@ export default class Sheet {
       const refSheet = this.sheetHolder.getSheet(refInfo.sheetKey)!;
       const refCell = refSheet.cellData.get(refCellKey)!;
 
-      const expr = new ExpressionHandler(refSheet, refCell.rawValue);
+      const expr = new ExpressionHandler(refSheet, refInfo, refCell.rawValue);
       const newValue = expr.updatePositionalReferences(from, to);
 
       // The formula may not change if the cell is being referenced indirectly through a range.
@@ -563,7 +563,11 @@ export default class Sheet {
     colKey: ColumnKey,
     rowKey: RowKey,
   ): boolean {
-    const expressionHandler = new ExpressionHandler(this, cell.rawValue);
+    const expressionHandler = new ExpressionHandler(
+      this,
+      { sheetKey: this.key, column: colKey, row: rowKey },
+      cell.rawValue,
+    );
     const evalResult = expressionHandler.evaluate();
     const prevState = cell.state;
     if (!evalResult) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,8 @@ import Events from "./core/event/events.ts";
 import SheetHolder from "./core/structure/sheetHolder.ts";
 import { DefaultColCount, DefaultRowCount } from "./utils/constants.ts";
 import LightSheetHelper from "./utils/helpers.ts";
+import ExpressionHandler from "./core/evaluation/expressionHandler.ts";
+import { CellReference } from "./core/structure/cell/types.cell.ts";
 
 export default class LightSheet {
   #ui: UI | undefined;
@@ -41,6 +43,13 @@ export default class LightSheet {
 
     if (options.onReady) options.onReady = this.options.onReady;
     this.onTableReady();
+  }
+
+  static registerFunction(
+    name: string,
+    func: (pos: CellReference, ...args: any[]) => string,
+  ) {
+    ExpressionHandler.registerFunction(name, func);
   }
 
   onTableReady() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,7 +71,7 @@ export default class LightSheet {
 
     const headerData = Array.from(
       { length: colLength + 1 }, // Adding 1 for the row number column
-      (_, i) => (i === 0 ? "" : LightSheetHelper.GenerateRowLabel(i)), // Generating row labels
+      (_, i) => (i === 0 ? "" : LightSheetHelper.generateColumnLabel(i)), // Generating column labels
     );
 
     this.#ui.addHeader(headerData);

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,7 +1,7 @@
 import { CoreSetCellPayload } from "../core/event/events.types.ts";
 
 export default class LightSheetHelper {
-  static GenerateRowLabel = (rowIndex: number) => {
+  static generateColumnLabel = (rowIndex: number) => {
     let label = "";
     const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     while (rowIndex > 0) {

--- a/tests/core/structure/customFunction.test.ts
+++ b/tests/core/structure/customFunction.test.ts
@@ -1,0 +1,50 @@
+import Sheet from "../../../src/core/structure/sheet.ts";
+import LightSheet from "../../../src/main.ts";
+import SheetHolder from "../../../src/core/structure/sheetHolder.ts";
+import { CellReference } from "../../../src/core/structure/cell/types.cell.ts";
+
+describe("Custom formula function test", () => {
+  let sheet: Sheet;
+
+  beforeEach(() => {
+    window.sheetHolder?.clear();
+    sheet = new Sheet("Sheet");
+    sheet.setCellAt(0, 0, "1"); // A1
+    sheet.setCellAt(1, 0, "2"); // B1
+    sheet.setCellAt(0, 1, "3"); // A2
+    sheet.setCellAt(1, 1, "4"); // B2
+    sheet.setCellAt(0, 2, "5"); // A3
+    sheet.setCellAt(1, 2, "6"); // B3
+
+    LightSheet.registerFunction("concat", (_, values: string[]) =>
+      values.join(""),
+    );
+
+    LightSheet.registerFunction(
+      "spread",
+      (cellPos: CellReference, value: string) => {
+        const sheet = SheetHolder.getInstance().getSheet(cellPos.sheetKey)!;
+        const colPos = sheet.getColumnIndex(cellPos.column)! + 1;
+        const rowPos = sheet.getRowIndex(cellPos.row)!;
+        for (let i = colPos; i < colPos + value.length; i++) {
+          sheet.setCellAt(i, rowPos, value[i - colPos]);
+        }
+        return value;
+      },
+    );
+  });
+
+  it("should combine all cells' values with concat", () => {
+    sheet.setCellAt(2, 0, "=concat(A1:B3)");
+    expect(sheet.getCellInfoAt(2, 0)?.resolvedValue).toBe("123456");
+  });
+
+  it("should use the spread function to manipulate cells in other columns", () => {
+    sheet.setCellAt(2, 1, '=spread("HI :)")');
+    expect(sheet.getCellInfoAt(3, 1)?.resolvedValue).toBe("H");
+    expect(sheet.getCellInfoAt(4, 1)?.resolvedValue).toBe("I");
+    expect(sheet.getCellInfoAt(5, 1)?.resolvedValue).toBe(" ");
+    expect(sheet.getCellInfoAt(6, 1)?.resolvedValue).toBe(":");
+    expect(sheet.getCellInfoAt(7, 1)?.resolvedValue).toBe(")");
+  });
+});

--- a/tests/core/structure/moveColumn.test.ts
+++ b/tests/core/structure/moveColumn.test.ts
@@ -56,14 +56,4 @@ describe("move column test", () => {
     expect(sheet.getCellInfoAt(2, 1)!.resolvedValue).toBe("3x2");
     expect(sheet.getCellInfoAt(1, 1)!.resolvedValue).toBe("1x2");
   });
-
-  it("should move a column without invalidating cell references", () => {
-    sheet.setCellAt(2, 0, "=A1");
-    sheet.setCellAt(2, 1, "=B1");
-    console.log(sheet.exportData());
-    sheet.moveColumn(1, 0);
-    console.log(sheet.exportData());
-    expect(sheet.getCellInfoAt(2, 0)!.rawValue).toBe("=B1");
-    expect(sheet.getCellInfoAt(2, 1)!.rawValue).toBe("=A1");
-  });
 });

--- a/tests/core/structure/moveColumn.test.ts
+++ b/tests/core/structure/moveColumn.test.ts
@@ -57,7 +57,7 @@ describe("move column test", () => {
     expect(sheet.getCellInfoAt(1, 1)!.resolvedValue).toBe("1x2");
   });
 
-  it("should swap two columns and referring formulas", () => {
+  it("should move a column without invalidating cell references", () => {
     sheet.setCellAt(2, 0, "=A1");
     sheet.setCellAt(2, 1, "=B1");
     console.log(sheet.exportData());

--- a/tests/core/structure/moveColumn.test.ts
+++ b/tests/core/structure/moveColumn.test.ts
@@ -56,4 +56,14 @@ describe("move column test", () => {
     expect(sheet.getCellInfoAt(2, 1)!.resolvedValue).toBe("3x2");
     expect(sheet.getCellInfoAt(1, 1)!.resolvedValue).toBe("1x2");
   });
+
+  it("should swap two columns and referring formulas", () => {
+    sheet.setCellAt(2, 0, "=A1");
+    sheet.setCellAt(2, 1, "=B1");
+    console.log(sheet.exportData());
+    sheet.moveColumn(1, 0);
+    console.log(sheet.exportData());
+    expect(sheet.getCellInfoAt(2, 0)!.rawValue).toBe("=B1");
+    expect(sheet.getCellInfoAt(2, 1)!.rawValue).toBe("=A1");
+  });
 });

--- a/tests/core/structure/referenceSymbols.test.ts
+++ b/tests/core/structure/referenceSymbols.test.ts
@@ -1,6 +1,6 @@
 import Sheet from "../../../src/core/structure/sheet.ts";
 
-describe("move column test", () => {
+describe("Cell reference symbol tests", () => {
   let sheet: Sheet;
 
   beforeEach(() => {

--- a/tests/core/structure/referenceSymbols.test.ts
+++ b/tests/core/structure/referenceSymbols.test.ts
@@ -1,0 +1,55 @@
+import Sheet from "../../../src/core/structure/sheet.ts";
+
+describe("move column test", () => {
+  let sheet: Sheet;
+
+  beforeEach(() => {
+    window.sheetHolder?.clear();
+    sheet = new Sheet("Sheet");
+    sheet.setCellAt(0, 0, "1x1");
+    sheet.setCellAt(1, 0, "2x1");
+    sheet.setCellAt(2, 0, "3x1");
+    sheet.setCellAt(0, 1, "1x2");
+    sheet.setCellAt(1, 1, "2x2");
+    sheet.setCellAt(2, 1, "3x2");
+  });
+
+  it("should move a column with cell references without invalidating them", () => {
+    sheet.setCellAt(2, 0, "=A1");
+    sheet.setCellAt(2, 1, "=B1");
+    sheet.moveColumn(1, 0);
+    expect(sheet.getCellInfoAt(2, 0)!.rawValue).toBe("=B1");
+    expect(sheet.getCellInfoAt(2, 1)!.rawValue).toBe("=A1");
+  });
+
+  it("should insert a column without invalidating references in the sheet", () => {
+    sheet.setCellAt(0, 0, "=C1");
+    sheet.setCellAt(0, 1, "=D1");
+    sheet.insertColumn(0);
+    expect(sheet.getCellInfoAt(1, 0)!.rawValue).toBe("=D1");
+    expect(sheet.getCellInfoAt(1, 1)!.rawValue).toBe("=E1");
+  });
+
+  it("should move a column anchoring a range reference and modify the range", () => {
+    sheet.setCellAt(6, 0, "=A1:C1");
+    sheet.moveColumn(2, 5);
+    expect(sheet.getCellInfoAt(6, 0)!.rawValue).toBe("=A1:F1");
+  });
+
+  it("should move a column within a range reference and leave the range unmodified", () => {
+    sheet.setCellAt(6, 0, "=A1:C1");
+    sheet.moveColumn(1, 5);
+    expect(sheet.getCellInfoAt(6, 0)!.rawValue).toBe("=A1:C1");
+  });
+
+  it("should insert a column without invalidating a cross-sheet reference", () => {
+    // Create a second sheet
+    const sheet2 = new Sheet("Sheet2");
+
+    sheet2.setCellAt(0, 0, "=Sheet!C1");
+    sheet2.setCellAt(0, 1, "=Sheet!D1");
+    sheet.insertColumn(0);
+    expect(sheet2.getCellInfoAt(0, 0)!.rawValue).toBe("=Sheet!D1");
+    expect(sheet2.getCellInfoAt(0, 1)!.rawValue).toBe("=Sheet!E1");
+  });
+});


### PR DESCRIPTION
Closes #123 , based on changes in #121 
* Add static `LightSheet.registerFunction` method for defining functions applied in expression parsing
* Inject `CellReference` parameter into all custom function calls from mathjs to allow accessing the sheet within the custom function
    * See tests for examples of defining custom functions