### PR TITLE
Fix set cell at and some refactoring

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -41,14 +41,11 @@ export default class LightSheet {
       }
 
       if (this.options.data) {
-        let rowIndex = 0;
-        for (const rowArray of this.options.data) {
-          let columnIndex = 0;
-          for (const cellValue of rowArray) {
-            this.sheet.setCellAt(columnIndex, rowIndex, cellValue);
-            columnIndex++;
+        for (let rowI = 0; rowI < this.options.data.length; rowI++) {
+          const rowData = this.options.data[rowI];
+          for (let colI = 0; colI < rowData.length; colI++) {
+            this.sheet.setCellAt(colI, rowI, rowData[colI]);
           }
-          rowIndex++;
         }
       }
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,20 +35,19 @@ export default class LightSheet {
     if (targetElement) {
       this.#ui = new UI(targetElement, this, this.options.toolbarOptions);
 
-      for (let index = 0; index < this.options.defaultColCount!; index++) {
-        this.#ui.addColumn();
-      }
-
-      for (let index = 0; index < this.options.defaultRowCount!; index++) {
-        this.#ui.addRow();
-      }
-
-      if (this.options.data) {
+      if (this.options.data && this.options.data.length > 0) {
         for (let rowI = 0; rowI < this.options.data.length; rowI++) {
           const rowData = this.options.data[rowI];
           for (let colI = 0; colI < rowData.length; colI++) {
             this.sheet.setCellAt(colI, rowI, rowData[colI]);
           }
+        }
+      } else {
+        for (let index = 0; index < this.options.defaultColCount!; index++) {
+          this.#ui.addColumn();
+        }
+        for (let index = 0; index < this.options.defaultRowCount!; index++) {
+          this.#ui.addRow();
         }
       }
     }

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -334,9 +334,9 @@ export default class UI {
 
     // Get the cell by either column and row key or position.
     // TODO Index-based ID may not be unique if there are multiple sheets.
-    const cellDom =
-      (cellDomKey && document.getElementById(cellDomKey)) ||
-      document.getElementById(`${columnIndex}_${rowIndex}`);
+    const cellDom = cellDomKey
+      ? document.getElementById(cellDomKey)
+      : document.getElementById(`${columnIndex}_${rowIndex}`);
 
     const newCellDomId = payload.clearCell
       ? `${columnIndex}_${rowIndex}`
@@ -344,14 +344,9 @@ export default class UI {
 
     const newRowDomId = payload.clearRow ? `row_${rowIndex}` : rowKey!;
 
-    let rowDom: HTMLElement | null = null;
-    if (rowKey) {
-      rowDom = document.getElementById(rowKey);
-    }
-    if (!rowDom) {
-      const rowId = `row_${rowIndex}`;
-      rowDom = document.getElementById(rowId);
-    }
+    const rowDom: HTMLElement | null = rowKey
+      ? document.getElementById(rowKey)
+      : document.getElementById(`row_${rowIndex}`);
 
     return {
       cellDom: cellDom,

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -354,7 +354,9 @@ export default class UI {
     const newRowDomId = payload.clearRow ? `row_${rowIndex}` : rowKey!;
 
     let rowDom: HTMLElement | null = null;
-    rowDom = document.getElementById(rowKey!);
+    if (rowKey) {
+      rowDom = document.getElementById(rowKey);
+    }
     if (!rowDom) {
       const rowId = `row_${rowIndex}`;
       rowDom = document.getElementById(rowId);

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -12,13 +12,13 @@ import { ToolbarItems } from "../utils/constants.ts";
 import { Coordinate } from "../utils/common.types.ts";
 
 export default class UI {
-  tableEl: Element;
+  tableEl!: Element;
   toolbarDom: HTMLElement | undefined;
   formulaBarDom!: HTMLElement | null;
   formulaInput!: HTMLInputElement;
   selectedCellDisplay!: HTMLElement;
-  tableHeadDom: Element;
-  tableBodyDom: Element;
+  tableHeadDom!: Element;
+  tableBodyDom!: Element;
   lightSheet: LightSheet;
   selectedCell: number[];
   selectedRowNumberCell: HTMLElement | null = null;
@@ -52,13 +52,23 @@ export default class UI {
     this.tableContainerDom = lightSheetContainerDom;
     lightSheetContainerDom.classList.add("lightsheet_table_container");
 
-    /*content*/
+    //table
+    this.createTableDom();
+
+    //toolbar
+    this.createToolbar();
+
+    //formula bar
+    this.createFormulaBar();
+  }
+
+  private createTableDom() {
     const tableDom = document.createElement("table");
     tableDom.classList.add("lightsheet_table");
     tableDom.setAttribute("cellpadding", "0");
     tableDom.setAttribute("cellspacing", "0");
     tableDom.setAttribute("unselectable", "yes");
-    lightSheetContainerDom.appendChild(tableDom);
+    this.tableContainerDom.appendChild(tableDom);
     this.tableEl = tableDom;
 
     //thead
@@ -77,15 +87,9 @@ export default class UI {
     //tbody
     this.tableBodyDom = document.createElement("tbody");
     tableDom.appendChild(this.tableBodyDom);
-
-    //toolbar
-    this.createToolbar();
-
-    //formula bar
-    this.createFormulaBar();
   }
 
-  createToolbar() {
+  private createToolbar() {
     if (
       !this.toolbarOptions.showToolbar ||
       this.toolbarOptions.items?.length == 0

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -312,22 +312,13 @@ export default class UI {
 
     // Get HTML elements and (new) IDs for the payload's cell and row.
     const elInfo = this.getElementInfoForSetCell(payload);
-    if (!elInfo.cellDom) {
-      elInfo.cellDom = this.addCell(
-        elInfo.rowDom!,
-        payload.indexPosition.column,
-        payload.indexPosition.row,
-        payload.formattedValue,
-        payload.keyPosition.columnKey?.toString(),
-      );
-    }
 
-    elInfo.cellDom.id = elInfo.cellDomId;
+    elInfo.cellDom!.id = elInfo.cellDomId;
     elInfo.rowDom!.id = elInfo.rowDomId;
 
     // Set cell value to resolved value from the core.
     // TODO Cell formula should be preserved. (Issue #49)
-    (elInfo.cellDom.firstChild! as HTMLInputElement).value =
+    (elInfo.cellDom!.firstChild! as HTMLInputElement).value =
       payload.formattedValue;
   }
 

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -218,7 +218,7 @@ export default class UI {
     this.tableHeadDom.children[0].appendChild(headerCellDom);
   }
 
-  private onClickHeaderCell(e: MouseEvent, indexOfTheHeader: number) {
+  private onClickHeaderCell(e: MouseEvent, columnIndex: number) {
     const selectedColumn = e.target as HTMLElement;
     if (!selectedColumn) return;
     const prevSelection = this.selectedHeaderCell;
@@ -232,7 +232,7 @@ export default class UI {
       this.selectedHeaderCell = selectedColumn;
       Array.from(this.tableBodyDom.children).forEach((childElement) => {
         // Code inside the forEach loop
-        childElement.children[indexOfTheHeader].classList.add(
+        childElement.children[columnIndex].classList.add(
           "lightsheet_table_selected_row_column",
         );
       });

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -300,20 +300,14 @@ export default class UI {
   private onCoreSetCell(event: LightsheetEvent) {
     const payload = event.payload as CoreSetCellPayload;
     // Create new columns if the column index is greater than the current column count.
-    const columnCount = this.getColumnCount();
-    if (payload.indexPosition.column > columnCount - 1) {
-      const diff = payload.indexPosition.column + 1 - columnCount;
-      for (let i = 0; i < diff; i++) {
-        this.addColumn();
-      }
+    const newColumns = payload.indexPosition.column - this.getColumnCount() + 1;
+    for (let i = 0; i < newColumns; i++) {
+      this.addColumn();
     }
 
-    const rowCount = this.getRowCount();
-    if (payload.indexPosition.row > rowCount - 1) {
-      const diff = payload.indexPosition.row + 1 - rowCount;
-      for (let i = 0; i < diff; i++) {
-        this.addRow();
-      }
+    const newRows = payload.indexPosition.row - this.getRowCount() + 1;
+    for (let i = 0; i < newRows; i++) {
+      this.addRow();
     }
 
     // Get HTML elements and (new) IDs for the payload's cell and row.

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,7 +1,5 @@
-import { CoreSetCellPayload } from "../core/event/events.types.ts";
-
 export default class LightSheetHelper {
-  static GenerateRowLabel = (rowIndex: number) => {
+  static GenerateColumnLabel = (rowIndex: number) => {
     let label = "";
     const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     while (rowIndex > 0) {
@@ -10,39 +8,5 @@ export default class LightSheetHelper {
       rowIndex = Math.floor(rowIndex / 26);
     }
     return label || "A"; // Return "A" if index is 0
-  };
-
-  static getElementInfoForSetCell = (payload: CoreSetCellPayload) => {
-    const colKey = payload.keyPosition.columnKey?.toString();
-    const rowKey = payload.keyPosition.rowKey?.toString();
-
-    const columnIndex = payload.indexPosition.column;
-    const rowIndex = payload.indexPosition.row;
-
-    const cellDomKey =
-      colKey && rowKey ? `${colKey!.toString()}_${rowKey!.toString()}` : null;
-
-    // Get the cell by either column and row key or position.
-    // TODO Index-based ID may not be unique if there are multiple sheets.
-    const cellDom =
-      (cellDomKey && document.getElementById(cellDomKey)) ||
-      document.getElementById(`${columnIndex}_${rowIndex}`);
-
-    const newCellDomId = payload.clearCell
-      ? `${columnIndex}_${rowIndex}`
-      : `${colKey}_${rowKey}`;
-
-    const newRowDomId = payload.clearRow ? `row_${rowIndex}` : rowKey!;
-
-    const rowDom =
-      (rowKey && document.getElementById(rowKey)) ||
-      document.getElementById(`row_${rowIndex}`);
-
-    return {
-      cellDom: cellDom,
-      cellDomId: newCellDomId,
-      rowDom: rowDom,
-      rowDomId: newRowDomId,
-    };
   };
 }

--- a/tests/ui/editability.test.ts
+++ b/tests/ui/editability.test.ts
@@ -6,6 +6,7 @@ describe("LightSheet", () => {
   beforeEach(() => {
     window.sheetHolder?.clear();
     targetElementMock = document.createElement("div");
+    document.body.appendChild(targetElementMock);
   });
 
   afterEach(() => {

--- a/tests/ui/initialtable.test.ts
+++ b/tests/ui/initialtable.test.ts
@@ -19,6 +19,7 @@ describe("LightSheet", () => {
       targetElementMock,
     );
 
+    document.body.appendChild(targetElementMock);
     expect(onReady).toHaveBeenCalledWith();
   });
 

--- a/tests/ui/setCellAt.test.ts
+++ b/tests/ui/setCellAt.test.ts
@@ -1,0 +1,47 @@
+import LightSheet from "../../src/main";
+
+describe("LightSheet setCellAt", () => {
+  let lightSheet: LightSheet;
+  let targetElementMock: HTMLElement;
+
+  beforeEach(() => {
+    // Mocking UI and target element
+    targetElementMock = document.createElement("div");
+
+    // Creating instance of LightSheet with mocked dependencies
+    window.sheetHolder?.clear();
+    lightSheet = new LightSheet(
+      {
+        sheetName: "Sheet",
+      },
+      targetElementMock,
+    );
+    document.body.appendChild(targetElementMock);
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("Should set the cell and use col and row keys", () => {
+    const cellInfo = lightSheet.setCellAt(1, 1, "test");
+
+    //Query the HTML via document else it will not be able to find the element
+    const cellId = cellInfo.position.columnKey + "_" + cellInfo.position.rowKey;
+    const cellElement = document.getElementById(cellId);
+
+    const cellInput = cellElement?.children[0] as HTMLInputElement;
+    expect(cellInput.value).toBe("test");
+  });
+
+  it("Should set the cell at the correct position in the DOM", () => {
+    lightSheet.setCellAt(2, 3, "test");
+
+    //Query the HTML via document else it will not be able to find the element
+    const tableElement = document.querySelector("table");
+    //This Table API accept position as 1 based index
+    const cellElement = tableElement?.rows[4]?.cells[3];
+
+    const cellInput = cellElement?.children[0] as HTMLInputElement;
+    expect(cellInput.value).toBe("test");
+  });
+});

--- a/tests/ui/toolBar.test.ts
+++ b/tests/ui/toolBar.test.ts
@@ -12,6 +12,7 @@ describe("Tool bar", () => {
 
   test("should create toolbar as the first child in the table container if no element is provided", () => {
     const targetElementMock: HTMLElement = document.createElement("div");
+    document.body.appendChild(targetElementMock);
 
     // Get the toolbar element
     new LightSheet(

--- a/tests/ui/toolBar.test.ts
+++ b/tests/ui/toolBar.test.ts
@@ -6,8 +6,6 @@ describe("Tool bar", () => {
     window.sheetHolder?.clear();
   });
 
-  afterEach(() => {});
-
   test("should create toolbar as the first child in the table container if no element is provided", () => {
     const targetElementMock: HTMLElement = document.createElement("div");
     document.body.appendChild(targetElementMock);


### PR DESCRIPTION
This PR fix issues with `SetCellAt`. `SetCellAt` Did not work correctly previously and inserted incorrect element into the DOM in certain situations. I need `SetCellAt` to work correctly for my other PRs.

While I was trying to figure out the problem with that function, I had to refactor something. 

Here are the main benefits of these changes:
- `SetCellAt` will work, in case the cell being set is outside the current default view layout (larger than the initial 4x4).
- Read to use `AddColumn` and `AddRow` function on the UI will allow us to easily expand the default row and column count.
- Respect the `LighSheetOptions` `defaultRowCount` and `defaultColCount`.
- Untangle `UI` and `main.ts`, where previously the initial table was being created in `main.ts` while it being a UI concern.

Additional tests were added + some fixes to other tests.
