### PR TITLE
66- create right click menu placeholder

### DIFF
--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -121,6 +121,10 @@ export default class UI {
       headerCellDom.textContent = headerData[i];
       headerRowDom.appendChild(headerCellDom);
 
+      headerRowDom.oncontextmenu = (e: MouseEvent) => {
+        e.preventDefault();
+      };
+
       if (i > 0) {
         headerCellDom.onclick = (e: MouseEvent) => {
           const selectedColumn = e.target as HTMLElement;
@@ -181,6 +185,10 @@ export default class UI {
           }
         }
       }
+    };
+
+    rowNumberCell.oncontextmenu = (e: MouseEvent) => {
+      e.preventDefault();
     };
     return rowDom;
   }
@@ -253,6 +261,10 @@ export default class UI {
       if (e.buttons === 1) {
         this.handleMouseOver(e, colIndex, rowIndex);
       }
+    };
+
+    inputDom.oncontextmenu = (e: MouseEvent) => {
+      e.preventDefault();
     };
 
     return cellDom;
@@ -398,6 +410,10 @@ export default class UI {
     });
   }
 
+  showMenu() {
+    console.log("TODO: Render menu here");
+  }
+
   handleMouseDown(e: MouseEvent, colIndex: number, rowIndex: number) {
     if (e.button === 0) {
       this.selectedCellsContainer.selectionStart =
@@ -407,6 +423,9 @@ export default class UI {
               column: colIndex,
             }
           : null;
+    } else if (e.button === 2) {
+      console.log("Right click /n TODO: Show menu");
+      this.showMenu();
     }
   }
 

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -15,6 +15,7 @@ export default class UI {
   toolbarDom: HTMLElement | undefined;
   tableHeadDom: Element;
   tableBodyDom: Element;
+  tableContextMenuDom: HTMLElement | undefined;
   lightSheet: LightSheet;
   selectedCell: number[];
   selectedRowNumberCell: HTMLElement | null = null;
@@ -49,6 +50,10 @@ export default class UI {
     /*toolbar*/
 
     this.createToolbar();
+
+    /*context menu*/
+    this.createContextMenu();
+    this.hideContextMenu();
 
     /*content*/
     const lightSheetContainerDom = document.createElement("div");
@@ -108,6 +113,46 @@ export default class UI {
     }
   }
 
+  createContextMenu(){
+    // Create context menu container
+    this.tableContextMenuDom = document.createElement('div');
+    this.tableContextMenuDom.id = 'contextMenu';
+    this.tableContextMenuDom.classList.add('lightsheet_table_context_menu');
+    
+    // Create options for the context menu
+    // TODO: Add working options and remove placeholders Copy, Cut, Paste
+    var options = ['Copy', 'Cut', 'Paste'];
+    
+    // Create UL element to hold menu options
+    var ul = document.createElement('ul');
+    
+    // Loop through options and create LI elements
+    options.forEach(function(option) {
+        var li = document.createElement('li');
+        li.textContent = option;
+        li.setAttribute('data-action', option.toLowerCase()); // Set data-action attribute for identification
+        ul.appendChild(li);
+    });
+    
+    // Append UL to context menu
+    this.tableContextMenuDom.appendChild(ul);
+
+    // Append context menu to document body
+    document.body.appendChild(this.tableContextMenuDom);
+  }
+
+  showContextMenu(x:number, y:number) {
+    let contextMenu = document.getElementById('contextMenu');
+    contextMenu!.style.display = 'block';
+    contextMenu!.style.left = x + 'px';
+    contextMenu!.style.top = y + 'px';
+}
+
+  hideContextMenu() {
+    let contextMenu = document.getElementById('contextMenu');
+    contextMenu!.style.display = 'none';
+}
+
   addHeader(headerData: string[]) {
     const headerRowDom = document.createElement("tr");
     this.tableHeadDom.appendChild(headerRowDom);
@@ -123,10 +168,12 @@ export default class UI {
 
       headerRowDom.oncontextmenu = (e: MouseEvent) => {
         e.preventDefault();
+        this.showContextMenu(e.clientX, e.clientY);
       };
 
       if (i > 0) {
         headerCellDom.onclick = (e: MouseEvent) => {
+          this.hideContextMenu();
           const selectedColumn = e.target as HTMLElement;
           if (!selectedColumn) return;
           const prevSelection = this.selectedHeaderCell;
@@ -161,6 +208,7 @@ export default class UI {
     );
     rowDom.appendChild(rowNumberCell);
     rowNumberCell.onclick = (e: MouseEvent) => {
+      this.hideContextMenu();
       const selectedRow = e.target as HTMLElement;
       if (!selectedRow) return;
       const prevSelection = this.selectedRowNumberCell;
@@ -189,7 +237,9 @@ export default class UI {
 
     rowNumberCell.oncontextmenu = (e: MouseEvent) => {
       e.preventDefault();
+      this.showContextMenu(e.clientX, e.clientY);
     };
+
     return rowDom;
   }
 
@@ -265,6 +315,7 @@ export default class UI {
 
     inputDom.oncontextmenu = (e: MouseEvent) => {
       e.preventDefault();
+      this.showContextMenu(e.clientX, e.clientY);
     };
 
     return cellDom;
@@ -415,7 +466,8 @@ export default class UI {
   }
 
   handleMouseDown(e: MouseEvent, colIndex: number, rowIndex: number) {
-    if (e.button === 0) {
+    if(e.button !==0) return;
+      this.hideContextMenu();
       this.selectedCellsContainer.selectionStart =
         (colIndex != null || undefined) && (rowIndex != null || undefined)
           ? {
@@ -423,10 +475,6 @@ export default class UI {
               column: colIndex,
             }
           : null;
-    } else if (e.button === 2) {
-      console.log("Right click /n TODO: Show menu");
-      this.showMenu();
-    }
   }
 
   handleMouseOver(e: MouseEvent, colIndex: number, rowIndex: number) {

--- a/src/ui/ui.css
+++ b/src/ui/ui.css
@@ -110,3 +110,26 @@ td:first-child {
 .lightsheet_table_selected_cell_range{
   background-color: var(--lightsheet-light-blue);
 }
+
+.lightsheet_table_context_menu {
+  display: none;
+  position: absolute;
+  background-color: var(--lightsheet-white);
+  border: 1px solid var(--lightsheet-silver-400);
+  z-index: 3;
+}
+
+.lightsheet_table_context_menu ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.lightsheet_table_context_menu li {
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.lightsheet_table_context_menu li:hover {
+  background-color: var(--lightsheet-light-blue);
+}


### PR DESCRIPTION
This PR contains work related to the right click menu.
- Remove default functionality for oncontextmenu
- Style the right click menu
- Implement the show and hide functionality of the right click menu

NOTE: Currently there are only placeholders as the options in the right click menu. They should be replaced with available functionality as we develop them.